### PR TITLE
Fix incorrect names of fragments in the action bar

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/AboutFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/AboutFragment.java
@@ -46,4 +46,10 @@ public class AboutFragment extends Fragment {
         featureRequest.setText(Html.fromHtml(text));
         return v;
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.about);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -166,4 +166,10 @@ public class DiningFragment extends ListFragment {
             }
         }
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.dining);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryFragment.java
@@ -116,18 +116,25 @@ public class DirectoryFragment extends ListFragment {
             }
         })
             .subscribe(new Action1<List<Person>>() {
-            @Override
-            public void call(List<Person> people) {
-                DirectoryAdapter mAdapter = new DirectoryAdapter(mContext, people);
-                getActivity().findViewById(R.id.loadingPanel).setVisibility(View.GONE);
-                if (people.size() == 0) {
-                    getActivity().findViewById(R.id.no_results).setVisibility(View.VISIBLE);
-                } else {
-                    mListView.setAdapter(mAdapter);
-                    getActivity().findViewById(R.id.no_results).setVisibility(View.GONE);
-                    getActivity().findViewById(android.R.id.list).setVisibility(View.VISIBLE);
+                @Override
+                public void call(List<Person> people) {
+                    DirectoryAdapter mAdapter = new DirectoryAdapter(mContext, people);
+                    getActivity().findViewById(R.id.loadingPanel).setVisibility(View.GONE);
+                    if (people.size() == 0) {
+                        getActivity().findViewById(R.id.no_results).setVisibility(View.VISIBLE);
+                    } else {
+                        mListView.setAdapter(mAdapter);
+                        getActivity().findViewById(R.id.no_results).setVisibility(View.GONE);
+                        getActivity().findViewById(android.R.id.list).setVisibility(View.VISIBLE);
+                    }
+                    searchView.clearFocus();
                 }
-                searchView.clearFocus();
-            }});
+            });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.directory);
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectorySearchFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectorySearchFragment.java
@@ -82,4 +82,9 @@ public class DirectorySearchFragment extends Fragment {
         searchView.setOnQueryTextListener(queryListener);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.directory);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
@@ -110,6 +110,12 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        setTitle(R.string.main_title);
+    }
+
     public void closeKeyboard() {
         InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         if (getCurrentFocus() != null) {
@@ -187,19 +193,7 @@ public class MainActivity extends AppCompatActivity {
                 .replace(R.id.content_frame, fragment)
                 .addToBackStack(null)
                 .commit();
-
-        fragmentManager.addOnBackStackChangedListener(new FragmentManager.OnBackStackChangedListener() {
-            @Override
-            public void onBackStackChanged() {
-                int backStackEntryCount = getSupportFragmentManager().getBackStackEntryCount();
-                if (backStackEntryCount == 0) { // If we are on the home screen then we should always
-                    setTitle("PennMobile");     // set the title to PennMobile
-                }
-            }
-        });
-
         mDrawerList.setItemChecked(position, true);
-        setTitle(mFeatureTitles[position]);
         mDrawerLayout.closeDrawer(mDrawerList);
     }
 
@@ -216,16 +210,6 @@ public class MainActivity extends AppCompatActivity {
             selectItem(5);
         } else if (v.getId() == R.id.map_img || v.getId() == R.id.map_cont || v.getId() == R.id.map_button) {
             selectItem(6);
-        }
-    }
-
-    public void setTitle(CharSequence title) {
-        if (getSupportActionBar() != null) {
-            if (title.equals("Home")) {
-                getSupportActionBar().setTitle("PennMobile");
-            } else {
-                getSupportActionBar().setTitle(title);
-            }
         }
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
@@ -53,4 +53,10 @@ public class MainFragment extends Fragment {
         return inflater.inflate(R.layout.fragment_main, container, false);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.main_title);
+    }
+
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MapFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MapFragment.java
@@ -159,6 +159,7 @@ public class MapFragment extends Fragment {
         mapView.onResume();
         super.onResume();
         mapCallBacks.requestLocationUpdates();
+        getActivity().setTitle(R.string.map);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
@@ -175,4 +175,9 @@ public class MenuFragment extends Fragment {
         }
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.dining);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsFragment.java
@@ -90,4 +90,10 @@ public class NewsFragment extends Fragment {
         tabs.setViewPager(pager);
         return v;
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.news);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsTab.java
@@ -118,6 +118,7 @@ public class NewsTab extends Fragment {
     @Override
     public void onResume() {
         mWebView.onResume();
+        getActivity().setTitle(R.string.news);
         super.onResume();
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarFragment.java
@@ -69,6 +69,7 @@ public class RegistrarFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        getActivity().setTitle(R.string.registrar);
         if (map == null) {
             map = mapFragment.getMap();
             if (map != null) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarListFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarListFragment.java
@@ -43,6 +43,11 @@ public class RegistrarListFragment extends ListFragment {
         onResume();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.registrar);
+    }
 }
 
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarSearchFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarSearchFragment.java
@@ -152,6 +152,12 @@ public class RegistrarSearchFragment extends Fragment {
                 }
             });
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.registrar);
+    }
 }
 
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SupportFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SupportFragment.java
@@ -41,4 +41,10 @@ public class SupportFragment extends ListFragment {
                              Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_support, container, false);
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.support);
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/TransitFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/TransitFragment.java
@@ -149,6 +149,7 @@ public class TransitFragment extends Fragment {
     @Override
     public void onResume() {
         mapView.onResume();
+        getActivity().setTitle(R.string.transit);
         super.onResume();
     }
 

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <!-- General -->
     <string name="app_name">PennMobile (Beta)</string>
+    <string name="main_title">PennMobile</string>
     <string name="action_settings">Settings</string>
     <string name="drawer_open">Open drawer</string>
     <string name="drawer_close">Close drawer</string>
@@ -12,6 +13,8 @@
     <string name="transit">Transit</string>
     <string name="directory">Directory</string>
     <string name="news">News</string>
+    <string name="support">Support</string>
+    <string name="about">About</string>
     <string name="labs_icon">Penn Labs</string>
     <string name="course_desc_title">Description</string>
     <string name="add_contact">Add contact</string>


### PR DESCRIPTION
By putting setTitle in each fragment's onResume method, the action bar is guaranteed to have the correct title, regardless of what series of clicks and events lead to the current screen.
