### PR TITLE
Makes about screen scrollable

### DIFF
--- a/PennMobile/src/main/res/layout/fragment_about.xml
+++ b/PennMobile/src/main/res/layout/fragment_about.xml
@@ -1,38 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:fillViewport="true" android:orientation="vertical"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+    <LinearLayout
+        android:orientation="vertical" android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <ImageView
-        android:id="@+id/labs_icon"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:contentDescription="@string/labs_icon"
-        android:paddingBottom="40dp"
-        android:paddingLeft="40dp"
-        android:paddingRight="40dp"
-        android:paddingTop="20dp"
-        android:src="@drawable/app_shared_logo" />
-
-    <TextView
-        tools:text="PennMobile was developed by Penn Labs, with funding and support from the Undergraduate Assembly"
-        android:id="@+id/about_desc"
-        android:paddingLeft="40dp"
-        android:paddingRight="40dp"
-        style="@style/MainText"/>
-
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp">
-        <Button
-            android:id="@+id/licenses"
-            android:layout_width="wrap_content"
+        <ImageView
+            android:id="@+id/labs_icon"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="Licenses" />
-    </RelativeLayout>
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/labs_icon"
+            android:paddingBottom="40dp"
+            android:paddingLeft="40dp"
+            android:paddingRight="40dp"
+            android:paddingTop="20dp"
+            android:src="@drawable/app_shared_logo" />
 
-</LinearLayout>
+        <TextView
+            tools:text="PennMobile was developed by Penn Labs, with funding and support from the Undergraduate Assembly"
+            android:id="@+id/about_desc"
+            android:paddingLeft="40dp"
+            android:paddingRight="40dp"
+            style="@style/MainText"/>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <Button
+                android:id="@+id/licenses"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="@string/licenses"/>
+        </RelativeLayout>
+    </LinearLayout>
+</ScrollView>

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -51,5 +51,8 @@
     <string name="routes_list">Routes</string>
     <string name="routes_ok">OK</string>
 
+    <!-- About -->
+    <string name="licenses">Licenses</string>
+
 
 </resources>


### PR DESCRIPTION
Before (unable to scroll to see entire Licenses button)
![before](https://cloud.githubusercontent.com/assets/3457673/8723287/849fd6d0-2b9a-11e5-8c08-8a1303d25846.png)

After (able to scroll)
![after](https://cloud.githubusercontent.com/assets/3457673/8723296/99936516-2b9a-11e5-85e6-582022e167c9.png)
