### PR TITLE
Remove transit buttons

### DIFF
--- a/PennMobile/src/main/res/layout/fragment_main.xml
+++ b/PennMobile/src/main/res/layout/fragment_main.xml
@@ -66,21 +66,22 @@
         </RelativeLayout>
 
         <RelativeLayout
-            android:id="@+id/transit_cont"
+            android:id="@+id/map_cont"
             style="@style/MainRelativeLayout">
 
             <ImageView
-                android:contentDescription="@string/transit"
-                android:id="@+id/transit_img"
-                android:src="@drawable/ic_transit"
+                android:contentDescription="@string/map"
+                android:id="@+id/map_img"
+                android:src="@drawable/ic_maps"
                 style="@style/MainIcon" />
 
             <TextView
-                android:id="@+id/transit_button"
-                android:layout_below="@+id/transit_img"
-                android:text="@string/transit"
+                android:id="@+id/map_button"
+                android:layout_below="@+id/map_img"
+                android:text="@string/map"
                 style="@style/MainText"/>
         </RelativeLayout>
+
     </TableRow>
 
     <TableRow style="@style/MainTableLayout">
@@ -100,25 +101,6 @@
                 android:id="@+id/news_button"
                 android:layout_below="@+id/news_img"
                 android:text="@string/news"
-                style="@style/MainText"/>
-        </RelativeLayout>
-
-
-        <RelativeLayout
-            android:id="@+id/map_cont"
-            android:layout_marginBottom="15dp"
-            style="@style/MainRelativeLayout">
-
-            <ImageView
-                android:contentDescription="@string/map"
-                android:id="@+id/map_img"
-                android:src="@drawable/ic_maps"
-                style="@style/MainIcon" />
-
-            <TextView
-                android:id="@+id/map_button"
-                android:layout_below="@+id/map_img"
-                android:text="@string/map"
                 style="@style/MainText"/>
         </RelativeLayout>
 

--- a/PennMobile/src/main/res/menu/navigation_drawer_items.xml
+++ b/PennMobile/src/main/res/menu/navigation_drawer_items.xml
@@ -22,11 +22,6 @@
             android:title="@string/dining"/>
 
         <item
-            android:id="@+id/nav_transit"
-            android:icon="@drawable/ic_directions_bus"
-            android:title="@string/transit"/>
-
-        <item
             android:id="@+id/nav_news"
             android:icon="@drawable/ic_announcement"
             android:title="@string/news"/>


### PR DESCRIPTION
Transit API has been deprecated, and replacement is not in place.
In the meantime, Transit should not be in the app since it is broken.