### PR TITLE
fix fragment transact

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.StrictMode;
 import android.support.annotation.AnyRes;
 import android.support.annotation.NonNull;
@@ -344,12 +345,18 @@ public class MainActivity extends AppCompatActivity {
 
     private void fragmentTransact(Fragment fragment) {
         if (fragment != null) {
-            FragmentManager fragmentManager = getSupportFragmentManager();
-            fragmentManager.beginTransaction()
-                    .replace(R.id.content_frame, fragment)
-                    .addToBackStack(null)
-                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-                    .commit();
+            final Fragment frag = fragment;
+            new Handler().post(new Runnable() {
+                @Override
+                public void run() {
+                    FragmentManager fragmentManager = getSupportFragmentManager();
+                    fragmentManager.beginTransaction()
+                            .replace(R.id.content_frame, frag)
+                            .addToBackStack(null)
+                            .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+                            .commit();
+                }
+            });
         }
         mDrawerLayout.closeDrawer(mDrawerList);
     }


### PR DESCRIPTION
Bug from frabic.io:
`Fatal Exception: java.lang.IllegalStateException: Could not execute method of the activity
       at android.view.View$1.onClick(View.java:4298)
       at android.view.View.performClick(View.java:5254)...
Caused by java.lang.reflect.InvocationTargetException
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)...
Caused by java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
       at android.support.v4.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1500)
       at android.support.v4.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1518)
       at android.support.v4.app.BackStackRecord.commitInternal(BackStackRecord.java:634)
       at android.support.v4.app.BackStackRecord.commit(BackStackRecord.java:613)
       at com.pennapps.labs.pennmobile.MainActivity.fragmentTransact(MainActivity.java:342)
       at com.pennapps.labs.pennmobile.MainActivity.navigateLayout(MainActivity.java:237)
       at com.pennapps.labs.pennmobile.MainActivity.onHomeButtonClick(MainActivity.java:241)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)...`

Fix found [here](http://stackoverflow.com/questions/14177781/java-lang-illegalstateexception-can-not-perform-this-action-after-onsaveinstanc)