### PR TITLE
fix daylight saving error on parsing json for dining

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/VenueInterval.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/VenueInterval.java
@@ -3,6 +3,7 @@ package com.pennapps.labs.pennmobile.classes;
 import com.google.gson.annotations.SerializedName;
 
 import org.joda.time.DateTime;
+import org.joda.time.IllegalInstantException;
 import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -58,7 +59,14 @@ public class VenueInterval {
                 closeTime = date + " " + "23:59:59";
             }
             DateTime openInstant = DateTime.parse(openTime, DATEFORMAT);
-            DateTime closeInstant = DateTime.parse(closeTime, DATEFORMAT);
+            DateTime closeInstant;
+            try {
+                closeInstant = DateTime.parse(closeTime, DATEFORMAT);
+            } catch (IllegalInstantException e) {
+                closeTime = date + " " + "01:00:00";
+                closeInstant = DateTime.parse(closeTime, DATEFORMAT);
+            }
+
             // Close hours sometimes given in AM hours of next day
             // Cutoff for "early morning" hours was decided to be 6AM
             if (closeInstant.getHourOfDay() < 6) {


### PR DESCRIPTION
Error log:
`org.joda.time.IllegalInstantException: Cannot parse "2017-03-12 02:00:00": Illegal instant due to time zone offset transition (America/New_York)
                                                                     at org.joda.time.format.DateTimeParserBucket.computeMillis(DateTimeParserBucket.java:471)
                                                                     at org.joda.time.format.DateTimeParserBucket.computeMillis(DateTimeParserBucket.java:411)
                                                                     at org.joda.time.format.DateTimeFormatter.parseDateTime(DateTimeFormatter.java:882)
                                                                     at org.joda.time.DateTime.parse(DateTime.java:160)
                                                                     at com.pennapps.labs.pennmobile.classes.VenueInterval$MealInterval.getInterval(VenueInterval.java:61)
                                                                     at com.pennapps.labs.pennmobile.classes.VenueInterval.getIntervals(VenueInterval.java:28)
                                                                     at com.pennapps.labs.pennmobile.classes.Venue.getHours(Venue.java:57)
                                                                     at com.pennapps.labs.pennmobile.DiningFragment$3.call(DiningFragment.java:102)
                                                                     at com.pennapps.labs.pennmobile.DiningFragment$3.call(DiningFragment.java:99)
                                                                     at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:55)
                                                                     at rx.internal.operators.OperatorMerge$InnerSubscriber.emit(OperatorMerge.java:676)
                                                                     at rx.internal.operators.OperatorMerge$InnerSubscriber.onNext(OperatorMerge.java:586)
                                                                     at rx.internal.operators.OnSubscribeFromIterable$IterableProducer.request(OnSubscribeFromIterable.java:106)
                                                                     at rx.Subscriber.setProducer(Subscriber.java:177)
                                                                     at rx.internal.operators.OnSubscribeFromIterable.call(OnSubscribeFromIterable.java:50)
                                                                     at rx.internal.operators.OnSubscribeFromIterable.call(OnSubscribeFromIterable.java:33)
                                                                     at rx.Observable.unsafeSubscribe(Observable.java:7531)
                                                                     at rx.internal.operators.OperatorMerge$MergeSubscriber.handleNewSource(OperatorMerge.java:215)
                                                                     at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:185)
                                                                     at rx.internal.operators.OperatorMerge$MergeSubscriber.onNext(OperatorMerge.java:120)
                                                                     at rx.internal.operators.OperatorMap$1.onNext(OperatorMap.java:55)
                                                                     at retrofit.RxSupport$2.run(RxSupport.java:56)
                                                                     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:423)
                                                                     at java.util.concurrent.FutureTask.run(FutureTask.java:237)
                                                                     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
                                                                     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
                                                                     at retrofit.Platform$Android$2$1.run(Platform.java:142)
                                                                     at java.lang.Thread.run(Thread.java:818)`