### PR TITLE
Add option to order dining by open status

### DIFF
--- a/PennMobile/src/main/AndroidManifest.xml
+++ b/PennMobile/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:value="@integer/google_play_services_version" />
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyDFOB7fgIQubKyOjjrmsgNoDt-xRvlBDrk" />
+            android:value="@string/google_api_key" />
 
         <activity
             android:name=".MainActivity"

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -1,11 +1,15 @@
 package com.pennapps.labs.pennmobile;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -58,11 +62,48 @@ public class DiningFragment extends ListFragment {
     }
 
     @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.dining_sort, menu);
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        String order = sp.getString("dining_sortBy", "RESIDENTIAL");
+        if (order.equals("RESIDENTIAL")) {
+            menu.findItem(R.id.action_sort_residential).setChecked(true);
+        }
+        else if (order.equals("NAME")) {
+            menu.findItem(R.id.action_sort_name).setChecked(true);
+        }
+        else {
+            menu.findItem(R.id.action_sort_open).setChecked(true);
+        }
+    }
+
+    private void setSortByMethod(String method) {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences.Editor editor = sp.edit();
+        editor.putString("dining_sortBy", method);
+        editor.apply();
+
+        getDiningHalls();
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handle presses on the action bar items
         switch (item.getItemId()) {
             case android.R.id.home:
                 mActivity.onBackPressed();
+                return true;
+            case R.id.action_sort_open:
+                setSortByMethod("OPEN");
+                item.setChecked(true);
+                return true;
+            case R.id.action_sort_residential:
+                setSortByMethod("RESIDENTIAL");
+                item.setChecked(true);
+                return true;
+            case R.id.action_sort_name:
+                setSortByMethod("NAME");
+                item.setChecked(true);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -44,8 +44,6 @@ public class DiningFragment extends ListFragment {
         mLabs = MainActivity.getLabsInstance();
         mActivity = (MainActivity) getActivity();
         mActivity.closeKeyboard();
-
-        setHasOptionsMenu(true);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -7,6 +7,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -44,6 +45,8 @@ public class DiningFragment extends ListFragment {
         mLabs = MainActivity.getLabsInstance();
         mActivity = (MainActivity) getActivity();
         mActivity.closeKeyboard();
+
+        setHasOptionsMenu(true);
     }
 
     @Override
@@ -75,6 +78,8 @@ public class DiningFragment extends ListFragment {
         else {
             menu.findItem(R.id.action_sort_open).setChecked(true);
         }
+        Fragment diningInfoFragment = getFragmentManager().findFragmentByTag("DINING_INFO_FRAGMENT");
+        menu.setGroupVisible(R.id.action_sort_by, diningInfoFragment == null || !diningInfoFragment.isVisible());
     }
 
     private void setSortByMethod(String method) {
@@ -122,7 +127,7 @@ public class DiningFragment extends ListFragment {
 
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         fragmentManager.beginTransaction()
-                .replace(R.id.dining_fragment, fragment)
+                .replace(R.id.dining_fragment, fragment, "DINING_INFO_FRAGMENT")
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
                 .addToBackStack(null)
                 .commitAllowingStateLoss();

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -7,6 +7,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -37,6 +38,7 @@ public class DiningFragment extends ListFragment {
     private MainActivity mActivity;
     @Bind(R.id.loadingPanel) RelativeLayout loadingPanel;
     @Bind(R.id.no_results) TextView no_results;
+    SwipeRefreshLayout swipeRefreshLayout;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -57,6 +59,14 @@ public class DiningFragment extends ListFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_dining, container, false);
         ButterKnife.bind(this, v);
+        swipeRefreshLayout = (SwipeRefreshLayout) v.findViewById(R.id.dining_swiperefresh);
+        swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                getDiningHalls();
+            }
+        });
+        swipeRefreshLayout.setColorSchemeResources(R.color.color_accent, R.color.color_primary);
         getDiningHalls();
         return v;
     }
@@ -157,6 +167,11 @@ public class DiningFragment extends ListFragment {
                                     mListView.setAdapter(adapter);
                                     loadingPanel.setVisibility(View.GONE);
                                 }
+                                try {
+                                    swipeRefreshLayout.setRefreshing(false);
+                                } catch (NullPointerException e){
+                                    //it has gone to another page.
+                                }
                             }
                         });
                     }
@@ -171,6 +186,11 @@ public class DiningFragment extends ListFragment {
                                 }
                                 if (no_results != null) {
                                     no_results.setVisibility(View.VISIBLE);
+                                }
+                                try {
+                                    swipeRefreshLayout.setRefreshing(false);
+                                } catch (NullPointerException e){
+                                    //it has gone to another page.
                                 }
                             }
                         });

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -166,6 +166,9 @@ public class DiningFragment extends ListFragment {
                                     DiningAdapter adapter = new DiningAdapter(mActivity, diningHalls);
                                     mListView.setAdapter(adapter);
                                     loadingPanel.setVisibility(View.GONE);
+                                    if (diningHalls.size() > 0) {
+                                        no_results.setVisibility(View.GONE);
+                                    }
                                 }
                                 try {
                                     swipeRefreshLayout.setRefreshing(false);
@@ -185,6 +188,7 @@ public class DiningFragment extends ListFragment {
                                     loadingPanel.setVisibility(View.GONE);
                                 }
                                 if (no_results != null) {
+                                    mListView.setAdapter(null);
                                     no_results.setVisibility(View.VISIBLE);
                                 }
                                 try {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -7,7 +7,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
@@ -4,7 +4,6 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
@@ -4,7 +4,10 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
@@ -65,6 +68,7 @@ public class DiningInfoFragment extends Fragment {
         fillInfo();
         return v;
     }
+
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -1,7 +1,9 @@
 package com.pennapps.labs.pennmobile.adapters;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,12 +31,16 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
     private final LayoutInflater inflater;
     private Labs mLabs;
     private boolean[] loaded;
+    private String sortBy;
 
     public DiningAdapter(Context context, List<DiningHall> diningHalls) {
         super(context, R.layout.dining_list_item, diningHalls);
         inflater = LayoutInflater.from(context);
         mLabs = MainActivity.getLabsInstance();
         loaded = new boolean[diningHalls.size()];
+
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        sortBy = sp.getString("dining_sortBy", "RESIDENTIAL");
     }
 
     @Override
@@ -126,13 +132,25 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
     private class MenuComparator implements Comparator<DiningHall> {
         @Override
         public int compare(DiningHall diningHall, DiningHall diningHall2) {
-            if (diningHall.isResidential() && !diningHall2.isResidential()) {
-                return -1;
-            } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
-                return 1;
-            } else {
-                return 0;
+            if (sortBy.equals("OPEN")) {
+                if (diningHall.isOpen() && !diningHall2.isOpen()) {
+                    return -1;
+                } else if (diningHall2.isOpen() && !diningHall.isOpen()) {
+                    return 1;
+                }
             }
+
+            if (!sortBy.equals("NAME")) {
+                if (diningHall.isResidential() && !diningHall2.isResidential()) {
+                    return -1;
+                } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
+                    return 1;
+                } else if (sortBy.equals("RESIDENTIAL")) {
+                    return 0;
+                }
+            }
+
+            return diningHall.getName().compareTo(diningHall2.getName());
         }
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -149,9 +149,7 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
                     else {
                         return diningHall.getName().compareTo(diningHall2.getName());
                     }
-                case "NAME":
-                    return diningHall.getName().compareTo(diningHall2.getName());
-                default:
+                case "RESIDENTIAL":
                     if (diningHall.isResidential() && !diningHall2.isResidential()) {
                         return -1;
                     } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
@@ -160,6 +158,8 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
                     else {
                         return 0;
                     }
+                default:
+                    return diningHall.getName().compareTo(diningHall2.getName());
             }
         }
     }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -41,6 +41,8 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
 
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         sortBy = sp.getString("dining_sortBy", "RESIDENTIAL");
+
+        this.sort(new MenuComparator());
     }
 
     @Override
@@ -125,7 +127,6 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
             progressBar.setVisibility(View.GONE);
             holder.menuArrow.setVisibility(View.VISIBLE);
         }
-        this.sort(new MenuComparator());
         return view;
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -132,25 +132,35 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
     private class MenuComparator implements Comparator<DiningHall> {
         @Override
         public int compare(DiningHall diningHall, DiningHall diningHall2) {
-            if (sortBy.equals("OPEN")) {
-                if (diningHall.isOpen() && !diningHall2.isOpen()) {
-                    return -1;
-                } else if (diningHall2.isOpen() && !diningHall.isOpen()) {
-                    return 1;
-                }
+            switch (sortBy) {
+                case "OPEN":
+                    if (sortBy.equals("OPEN")) {
+                        if (diningHall.isOpen() && !diningHall2.isOpen()) {
+                            return -1;
+                        } else if (diningHall2.isOpen() && !diningHall.isOpen()) {
+                            return 1;
+                        }
+                    }
+                    if (diningHall.isResidential() && !diningHall2.isResidential()) {
+                        return -1;
+                    } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
+                        return 1;
+                    }
+                    else {
+                        return diningHall.getName().compareTo(diningHall2.getName());
+                    }
+                case "NAME":
+                    return diningHall.getName().compareTo(diningHall2.getName());
+                default:
+                    if (diningHall.isResidential() && !diningHall2.isResidential()) {
+                        return -1;
+                    } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
+                        return 1;
+                    }
+                    else {
+                        return 0;
+                    }
             }
-
-            if (!sortBy.equals("NAME")) {
-                if (diningHall.isResidential() && !diningHall2.isResidential()) {
-                    return -1;
-                } else if (diningHall2.isResidential() && !diningHall.isResidential()) {
-                    return 1;
-                } else if (sortBy.equals("RESIDENTIAL")) {
-                    return 0;
-                }
-            }
-
-            return diningHall.getName().compareTo(diningHall2.getName());
         }
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -134,12 +134,10 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
         public int compare(DiningHall diningHall, DiningHall diningHall2) {
             switch (sortBy) {
                 case "OPEN":
-                    if (sortBy.equals("OPEN")) {
-                        if (diningHall.isOpen() && !diningHall2.isOpen()) {
-                            return -1;
-                        } else if (diningHall2.isOpen() && !diningHall.isOpen()) {
-                            return 1;
-                        }
+                    if (diningHall.isOpen() && !diningHall2.isOpen()) {
+                        return -1;
+                    } else if (diningHall2.isOpen() && !diningHall.isOpen()) {
+                        return 1;
                     }
                     if (diningHall.isResidential() && !diningHall2.isResidential()) {
                         return -1;

--- a/PennMobile/src/main/res/layout/fragment_dining.xml
+++ b/PennMobile/src/main/res/layout/fragment_dining.xml
@@ -13,12 +13,17 @@
         android:id="@+id/dining_fragment"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
-        <ListView
-            tools:visibility="visible"
-            tools:listitem="@layout/dining_list_item"
-            android:id="@android:id/list"
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/dining_swiperefresh"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent">
+            <ListView
+                tools:visibility="visible"
+                tools:listitem="@layout/dining_list_item"
+                android:id="@android:id/list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </android.support.v4.widget.SwipeRefreshLayout>
     </FrameLayout>
 
 </LinearLayout>

--- a/PennMobile/src/main/res/menu/dining_sort.xml
+++ b/PennMobile/src/main/res/menu/dining_sort.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:id="@+id/action_sort_by" android:checkableBehavior="single">
+        <item
+            android:id="@+id/action_sort_name"
+            android:title="@string/sort_by_name"/>
+        <item
+            android:id="@+id/action_sort_residential"
+            android:title="@string/sort_by_residential" />
+        <item
+            android:id="@+id/action_sort_open"
+            android:title="@string/sort_by_open" />
+    </group>
+</menu>

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="menu_arg_name">name</string>
     <string name="menu_arg_meal">meal</string>
     <string name="menu_arg_stations">stations</string>
+    <string name="sort_by_name">Order by Name</string>
+    <string name="sort_by_residential">Order by Residential Hall</string>
+    <string name="sort_by_open">Order by Open Status</string>
 
     <!-- Courses -->
     <string name="course">Average Course</string>

--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ To get started running the app, just follow the following instructions:
 2. Git clone the repository into your Android Studio workspace
 3. Using the SDK Manager, install the Android SDK 22, Build Tools 22.0.1, Google repository, Android support library, and any other dependencies of the app.
 4. Open the project using Android Studio by double clicking the `build.gradle` file in the root directory of the project.
-5. Build the app and make sure that Gradle fetches all the proper dependencies. If you are prompted to install additional dependencies, definitely do so.
-6. You should be able to build the app, and then run it on an Android simulator or an actual Android phone/tablet
+5. Copy the `api-keys.xml.sample` file to `PennMobile/src/main/res/values/api-keys.xml` and follow the instructions inside the file to obtain API keys.
+6. Build the app and make sure that Gradle fetches all the proper dependencies. If you are prompted to install additional dependencies, definitely do so.
+7. You should be able to build the app, and then run it on an Android simulator or an actual Android phone/tablet.

--- a/api-keys.xml.sample
+++ b/api-keys.xml.sample
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Get a Google Maps API key from https://developers.google.com/maps/documentation/android-api/signup -->
+    <string name="google_api_key"></string>
+</resources>


### PR DESCRIPTION
This edit makes it possible to change the order that the dining halls are listed in. There are three options:

- Order by Name - This orders all of the dining halls in alphabetical order.
- Order by Residential Hall - This keeps the current ordering of the dining halls, and is the default option.
- Order by Open Status - This puts all of the currently open dining halls at the top.

Also added some documentation on how to set up an API key in order to make the app run.

<img src="https://user-images.githubusercontent.com/4441174/30245307-ce03b5d4-95a2-11e7-8a54-bb36b51199df.png" width="300px" />
<img src="https://user-images.githubusercontent.com/4441174/30245306-ce003878-95a2-11e7-9aef-0762df08e924.png" width="300px" />