### PR TITLE
Add ability to view dining hall data offline

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -14,6 +14,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -44,7 +45,8 @@ public class DiningFragment extends ListFragment {
     private MainActivity mActivity;
     @Bind(R.id.loadingPanel) RelativeLayout loadingPanel;
     @Bind(R.id.no_results) TextView no_results;
-    SwipeRefreshLayout swipeRefreshLayout;
+    @Bind(R.id.dining_swiperefresh) SwipeRefreshLayout swipeRefreshLayout;
+    @Bind(R.id.dining_cache_warning) TextView cache_warning;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -59,13 +61,30 @@ public class DiningFragment extends ListFragment {
         super.onActivityCreated(savedInstanceState);
         setHasOptionsMenu(true);
         mListView = getListView();
+
+        // this prevents the refresh from being called when the list is not
+        // scrolled to the top, which allows the user to scroll up
+        mListView.setOnScrollListener(new AbsListView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(AbsListView absListView, int i) {
+
+            }
+
+            @Override
+            public void onScroll(AbsListView absListView, int i, int i1, int i2) {
+                int topRowVerticalPosition = 0;
+                if (mListView != null && mListView.getChildCount() != 0) {
+                    topRowVerticalPosition = mListView.getChildAt(0).getTop();
+                }
+                swipeRefreshLayout.setEnabled(i == 0 && topRowVerticalPosition >= 0);
+            }
+        });
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_dining, container, false);
         ButterKnife.bind(this, v);
-        swipeRefreshLayout = (SwipeRefreshLayout) v.findViewById(R.id.dining_swiperefresh);
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
@@ -179,6 +198,7 @@ public class DiningFragment extends ListFragment {
                                     });
                                     mListView.setAdapter(adapter);
                                     loadingPanel.setVisibility(View.GONE);
+                                    cache_warning.setVisibility(View.GONE);
                                     if (diningHalls.size() > 0) {
                                         no_results.setVisibility(View.GONE);
                                     }
@@ -209,6 +229,7 @@ public class DiningFragment extends ListFragment {
                                 }
                                 else {
                                     if (loadingPanel != null) {
+                                        cache_warning.setVisibility(View.VISIBLE);
                                         DiningAdapter adapter = new DiningAdapter(mActivity, cachedInfo);
                                         mListView.setAdapter(adapter);
                                         loadingPanel.setVisibility(View.GONE);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -171,11 +171,16 @@ public class DiningFragment extends ListFragment {
                             public void run() {
                                 if (loadingPanel != null) {
                                     DiningAdapter adapter = new DiningAdapter(mActivity, diningHalls);
+                                    adapter.addMenuLoadListener(new DiningAdapter.MenuLoadListener() {
+                                        @Override
+                                        public void onLoad() {
+                                            saveCache(diningHalls);
+                                        }
+                                    });
                                     mListView.setAdapter(adapter);
                                     loadingPanel.setVisibility(View.GONE);
                                     if (diningHalls.size() > 0) {
                                         no_results.setVisibility(View.GONE);
-                                        saveCache(diningHalls);
                                     }
                                 }
                                 try {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
@@ -42,6 +42,8 @@ public class MenuFragment extends Fragment {
             headers = new ArrayList<>();
         }
 
+
+
         private void addTabs(DiningHall hall) {
             List<DiningHall.Menu> menus = hall.menus;
             name = hall.getName();

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/DiningHall.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/DiningHall.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName;
 
 import org.joda.time.Interval;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class DiningHall implements Parcelable {
+public class DiningHall implements Parcelable, Serializable {
 
     private int id;
     private String name;
@@ -171,7 +172,7 @@ public class DiningHall implements Parcelable {
     * Created by Adel on 12/18/14.
             * Class for a single menu, ie. Lunch, Dinner
     */
-    public static class Menu implements Parcelable{
+    public static class Menu implements Parcelable, Serializable {
         @SerializedName("txtDayPartDescription") public String name;
         @SerializedName("tblStation") public List<DiningStation> stations = new ArrayList<>();
 
@@ -206,7 +207,7 @@ public class DiningHall implements Parcelable {
      * Created by Adel on 12/18/14.
      * Class for a station at a dining hall
      */
-    public static class DiningStation {
+    public static class DiningStation implements Serializable {
         @SerializedName("txtStationDescription") public String name;
         @SerializedName("tblItem") public List<FoodItem> items = new ArrayList<>();
     }
@@ -215,7 +216,7 @@ public class DiningHall implements Parcelable {
      * Created by Adel on 12/18/14.
      * Class for Food items in Dining menus
      */
-    public static class FoodItem {
+    public static class FoodItem implements Serializable {
         @SerializedName("txtTitle") public String title;
         @SerializedName("txtDescription") String description;
     }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/Venue.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/Venue.java
@@ -7,6 +7,7 @@ import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.Map;
  * Created by Adel on 12/16/14.
  * Class for Dining Venues from Business Services API
  */
-public class Venue {
+public class Venue implements Serializable {
     public int id;
     public String name;
     public String venueType;

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/VenueInterval.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/classes/VenueInterval.java
@@ -8,6 +8,7 @@ import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 
@@ -15,7 +16,7 @@ import java.util.List;
  * Interval for venues with meal name and Joda Intervals
  * Created by Adel on 7/13/15.
  */
-public class VenueInterval {
+public class VenueInterval implements Serializable {
     public String date;
     @SerializedName("meal") public List<MealInterval> meals;
 
@@ -32,7 +33,7 @@ public class VenueInterval {
         return openHours;
     }
 
-    public static class MealInterval {
+    public static class MealInterval implements Serializable {
         public String open;
         public String close;
         public String type;

--- a/PennMobile/src/main/res/layout/fragment_dining.xml
+++ b/PennMobile/src/main/res/layout/fragment_dining.xml
@@ -17,12 +17,27 @@
             android:id="@+id/dining_swiperefresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-            <ListView
+            <LinearLayout
+                android:layout_height="match_parent"
+                android:layout_width="match_parent"
+                android:clickable="true"
+                android:orientation="vertical">
+                <TextView
+                    tools:visibility="gone"
+                    android:id="@+id/dining_cache_warning"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="#FFEB3B"
+                    android:padding="10dp"
+                    android:textSize="18sp"
+                    android:text="@string/cache_warning" />
+                <ListView
                 tools:visibility="visible"
                 tools:listitem="@layout/dining_list_item"
                 android:id="@android:id/list"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
+            </LinearLayout>
         </android.support.v4.widget.SwipeRefreshLayout>
     </FrameLayout>
 

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="sort_by_name">Order by Name</string>
     <string name="sort_by_residential">Order by Residential Hall</string>
     <string name="sort_by_open">Order by Open Status</string>
+    <string name="no_data_msg">Cannot display Map: wifi/data not enabled</string>
 
     <!-- Courses -->
     <string name="course">Average Course</string>

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="sort_by_residential">Order by Residential Hall</string>
     <string name="sort_by_open">Order by Open Status</string>
     <string name="no_data_msg">Cannot display Map: wifi/data not enabled</string>
+    <string name="cache_warning">The data shown below is not up to date. Connect to the internet to retrieve the latest dining hall information.</string>
 
     <!-- Courses -->
     <string name="course">Average Course</string>


### PR DESCRIPTION
Add the ability to cache dining hall hours and menus for cases when there is no wifi/data. Also displays a warning to the user indicating that this information is cached.

Uses a commit from @mike2151 to fix #441, which is necessary in order to make caching work correctly.

<img src="https://user-images.githubusercontent.com/4441174/33134939-0bfea1e0-cf6f-11e7-851c-9c0e074b8364.png" width="300px">
