### PR TITLE
Update sdk gradle libraries

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -4,9 +4,10 @@ buildscript {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
         maven { url "https://jitpack.io" }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'io.fabric.tools:gradle:1.25.1'
     }
 }
@@ -15,19 +16,26 @@ apply plugin: 'io.fabric'
 
 repositories {
     mavenCentral()
-    maven { url 'https://maven.fabric.io/public' }
+    jcenter()
+    maven { url "https://maven.fabric.io/public" }
     maven { url "https://jitpack.io" }
+    google()
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
-
+    buildTypes {
+        debug {
+            matchingFallbacks = ['qa', 'release']
+        }
+        release {}
+    }
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
+        vectorDrawables.useSupportLibrary = true
     }
-
     packagingOptions {
         pickFirst 'META-INF/LICENSE.txt'
         pickFirst 'META-INF/NOTICE.txt'
@@ -35,33 +43,35 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile('com.crashlytics.sdk.android:crashlytics:2.8.0@aar') {
-        transitive = true;
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.4@aar') {
+        transitive = true
     }
-    compile 'com.google.maps:google-maps-services:0.1.11'
-    compile 'org.jsoup:jsoup:1.10.1'
-    compile 'com.android.support:percent:25.3.1'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:preference-v7:25.3.1'
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
-    compile 'com.google.android.gms:play-services-location:8.4.0'
-    compile 'joda-time:joda-time:2.8.1'
-    compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.okhttp:okhttp:2.4.0'
-    compile 'io.reactivex:rxandroid:0.25.0'
-    compile 'com.android.support:customtabs:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.daimajia.swipelayout:library:1.2.0@aar'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    testCompile 'junit:junit:4.12'
-    androidTestCompile 'org.testng:testng:6.9.6'
-    compile 'com.github.PhilJay:MPAndroidChart:v3.0.3'
-    compile 'com.android.support:cardview-v7:25.3.1'
+    implementation 'com.google.maps:google-maps-services:0.2.10'
+    implementation 'org.jsoup:jsoup:1.11.3'
+    implementation 'com.android.support:percent:27.1.1'
+    implementation 'com.android.support:exifinterface:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:preference-v7:27.1.1'
+    implementation 'com.google.android.gms:play-services-maps:15.0.1'
+    implementation 'com.google.android.gms:play-services-location:15.0.1'
+    implementation 'joda-time:joda-time:2.10'
+    implementation 'org.apache.commons:commons-lang3:3.7'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.jakewharton:butterknife:8.8.1'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+    implementation 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation 'com.squareup.okhttp:okhttp:2.7.5'
+    implementation 'io.reactivex:rxandroid:1.2.1'
+    implementation 'com.android.support:customtabs:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.android.support:support-v4:27.1.1'
+    implementation 'com.daimajia.swipelayout:library:1.2.0@aar'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.testng:testng:6.14.3'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
+    implementation 'com.android.support:cardview-v7:27.1.1'
 }
 

--- a/PennMobile/src/main/AndroidManifest.xml
+++ b/PennMobile/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!-- for Google Maps API -->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="com.pennapps.labs.pennmobile.permission.MAPS_RECEIVE" />
@@ -71,7 +70,7 @@
 
         <!-- receiver for laundry -->
         <receiver
-            android:name=".LaundryBroadcastReceiverNew"
+            android:name=".LaundryBroadcastReceiver"
             android:enabled="true"
             android:exported="true" />
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/AboutFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/AboutFragment.java
@@ -13,9 +13,11 @@ import android.widget.TextView;
 
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import butterknife.Unbinder;
 
 public class AboutFragment extends Fragment {
     private AlertDialog mAlertDialog;
+    private Unbinder unbinder;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -26,7 +28,7 @@ public class AboutFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_about, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         TextView featureRequest = (TextView) v.findViewById(R.id.about_desc);
         featureRequest.setMovementMethod(LinkMovementMethod.getInstance());
         String text = "Penn Mobile was developed by Penn Labs, with funding<br>" +
@@ -47,7 +49,7 @@ public class AboutFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 
     @OnClick(R.id.about_desc)

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/BookGsrFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/BookGsrFragment.java
@@ -16,25 +16,23 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import retrofit.Callback;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 
 public class BookGsrFragment extends Fragment {
 
+    @BindView(R.id.first_name) EditText firstName;
+    @BindView(R.id.last_name) EditText lastName;
+    @BindView(R.id.gsr_email) EditText email;
+    @BindView(R.id.submit_gsr) Button submit;
+    private Unbinder unbinder;
+
     private Labs mLabs;
-
-    @Bind(R.id.first_name)
-    EditText firstName;
-    @Bind(R.id.last_name) EditText lastName;
-    @Bind(R.id.gsr_email) EditText email;
-    @Bind(R.id.submit_gsr)
-    Button submit;
-
     private String gsrID, gsrLocationCode, startTime, endTime;
-
 
     public BookGsrFragment() {
         // Required empty public constructor
@@ -75,7 +73,7 @@ public class BookGsrFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.gsr_details_book, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         submit.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
 
@@ -95,7 +93,7 @@ public class BookGsrFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 
     private void bookGSR(int gsrId, int gsrLocationCode, String startTime, String endTime){

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/CourseFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/CourseFragment.java
@@ -27,12 +27,25 @@ import com.pennapps.labs.pennmobile.classes.Review;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
 public class CourseFragment extends Fragment implements OnMapReadyCallback {
+
+    @BindView(R.id.course_activity) TextView courseActivityTextView;
+    @BindView(R.id.course_title) TextView courseTitleTextView;
+    @BindView(R.id.instructor) TextView instructorTextView;
+    @BindView(R.id.course_desc_title) TextView descriptionTitle;
+    @BindView(R.id.course_desc) TextView descriptionTextView;
+    @BindView(R.id.registrar_map_frame) View mapFrame;
+    @BindView(R.id.pcr_layout) LinearLayout pcrLayout;
+    @BindView(R.id.course_avg_course) TextView courseQuality;
+    @BindView(R.id.course_avg_instr) TextView instructorQuality;
+    @BindView(R.id.course_avg_diff) TextView courseDifficulty;
+    private Unbinder unbinder;
 
     private GoogleMap map;
     private SupportMapFragment mapFragment;
@@ -40,17 +53,6 @@ public class CourseFragment extends Fragment implements OnMapReadyCallback {
     private Labs mLabs;
     private MainActivity mActivity;
     private boolean fav;
-
-    @Bind(R.id.course_activity) TextView courseActivityTextView;
-    @Bind(R.id.course_title) TextView courseTitleTextView;
-    @Bind(R.id.instructor) TextView instructorTextView;
-    @Bind(R.id.course_desc_title) TextView descriptionTitle;
-    @Bind(R.id.course_desc) TextView descriptionTextView;
-    @Bind(R.id.registrar_map_frame) View mapFrame;
-    @Bind(R.id.pcr_layout) LinearLayout pcrLayout;
-    @Bind(R.id.course_avg_course) TextView courseQuality;
-    @Bind(R.id.course_avg_instr) TextView instructorQuality;
-    @Bind(R.id.course_avg_diff) TextView courseDifficulty;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -65,7 +67,7 @@ public class CourseFragment extends Fragment implements OnMapReadyCallback {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_course, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         return v;
     }
 
@@ -160,7 +162,7 @@ public class CourseFragment extends Fragment implements OnMapReadyCallback {
         } else {
             getActivity().setTitle(R.string.registrar);
         }
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 
     private void drawCourseMap() {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.java
@@ -28,8 +28,9 @@ import com.pennapps.labs.pennmobile.classes.Venue;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import io.fabric.sdk.android.Fabric;
 import rx.Observable;
 import rx.functions.Action1;
@@ -37,11 +38,13 @@ import rx.functions.Func1;
 
 public class DiningFragment extends ListFragment {
 
+    @BindView(R.id.loadingPanel) RelativeLayout loadingPanel;
+    @BindView(R.id.no_results) TextView no_results;
+    private Unbinder unbinder;
+
     private Labs mLabs;
     private ListView mListView;
     private MainActivity mActivity;
-    @Bind(R.id.loadingPanel) RelativeLayout loadingPanel;
-    @Bind(R.id.no_results) TextView no_results;
     SwipeRefreshLayout swipeRefreshLayout;
 
     @Override
@@ -67,7 +70,7 @@ public class DiningFragment extends ListFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_dining, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         swipeRefreshLayout = (SwipeRefreshLayout) v.findViewById(R.id.dining_swiperefresh);
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
@@ -221,6 +224,6 @@ public class DiningFragment extends ListFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
@@ -34,8 +35,9 @@ import org.joda.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
@@ -43,7 +45,11 @@ import rx.functions.Action1;
  * Created by Lily on 11/13/2015.
  * Fragment for Dining information (hours, map)
  */
-public class DiningInfoFragment extends Fragment {
+public class DiningInfoFragment extends Fragment implements OnMapReadyCallback {
+
+    @BindView(R.id.dining_hours) RelativeLayout menuParent;
+    @BindView(R.id.dining_map_frame) View mapFrame;
+    private Unbinder unbinder;
 
     private DiningHall mDiningHall;
     private MainActivity mActivity;
@@ -51,9 +57,6 @@ public class DiningInfoFragment extends Fragment {
 
     private GoogleMap map;
     private SupportMapFragment mapFragment;
-
-    @Bind(R.id.dining_hours) RelativeLayout menuParent;
-    @Bind(R.id.dining_map_frame) View mapFrame;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -67,7 +70,7 @@ public class DiningInfoFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_dining_info, container, false);
         v.setBackgroundColor(Color.WHITE);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         fillInfo();
         return v;
     }
@@ -185,24 +188,14 @@ public class DiningInfoFragment extends Fragment {
         mActivity.getActionBarToggle().syncState();
         getActivity().setTitle(mDiningHall.getName());
         if (map == null) {
-            map = mapFragment.getMap();
-            if (map != null) {
-                map.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(39.95198, -75.19368), 17));
-                map.getUiSettings().setZoomControlsEnabled(false);
-            }
-        }
-        if (isNetworkAvailable()) {
-            drawMap();
-        }
-        else {
-            Toast.makeText(getActivity(), getResources().getString(R.string.no_data_msg), Toast.LENGTH_LONG).show();
+            mapFragment.getMapAsync(this);
         }
     }
     @Override
     public void onDestroyView() {
         super.onDestroyView();
         getActivity().setTitle(mDiningHall.getName());
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
     @Override
     public void onDestroy() {
@@ -210,5 +203,17 @@ public class DiningInfoFragment extends Fragment {
     }
 
 
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        map = googleMap;
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(39.95198, -75.19368), 17));
+        map.getUiSettings().setZoomControlsEnabled(false);
+        if (isNetworkAvailable()) {
+            drawMap();
+        }
+        else {
+            Toast.makeText(getActivity(), getResources().getString(R.string.no_data_msg), Toast.LENGTH_LONG).show();
+        }
+    }
 }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryFragment.java
@@ -10,12 +10,13 @@ import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.answers.Answers;
 import com.crashlytics.android.answers.ContentViewEvent;
 
-import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import io.fabric.sdk.android.Fabric;
 
 public class DirectoryFragment extends SearchFavoriteFragment {
 
     private DirectoryTabAdapter adapter;
+    private Unbinder unbinder;
 
     protected class DirectoryTabAdapter extends ListTabAdapter {
 
@@ -92,7 +93,9 @@ public class DirectoryFragment extends SearchFavoriteFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+        if (unbinder != null) {
+            unbinder.unbind();
+        }
     }
 
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DirectoryTab.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
@@ -27,12 +28,13 @@ import rx.functions.Action1;
 public class DirectoryTab extends SearchFavoriteTab {
 
     private DirectoryAdapter mAdapter;
+    private Unbinder unbinder;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
         View v = inflater.inflate(R.layout.fragment_search_favorite_tab, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         mListView = (ListView) v.findViewById(android.R.id.list);
         initList();
         return v;
@@ -123,5 +125,11 @@ public class DirectoryTab extends SearchFavoriteTab {
         } else {
             search_instructions.setText(getString(R.string.directory_instructions));
         }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingFragment.java
@@ -19,15 +19,16 @@ import com.pennapps.labs.pennmobile.classes.FlingEvent;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import io.fabric.sdk.android.Fabric;
 import rx.functions.Action1;
 
 public class FlingFragment extends Fragment {
 
-    @Bind(R.id.fling_fragment_recyclerview)
-    RecyclerView flingFragmentRecyclerView;
+    @BindView(R.id.fling_fragment_recyclerview) RecyclerView flingFragmentRecyclerView;
+    private Unbinder unbinder;
 
     List<FlingEvent> flingEvents;
 
@@ -55,7 +56,7 @@ public class FlingFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_fling, container, false);
-        ButterKnife.bind(this, view);
+        unbinder = ButterKnife.bind(this, view);
         Labs labs = MainActivity.getLabsInstance();
         labs.getFlingEvents().subscribe(new Action1<List<FlingEvent>>() {
             @Override
@@ -97,5 +98,11 @@ public class FlingFragment extends Fragment {
     @Override
     public void onDetach() {
         super.onDetach();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingPerformanceViewHolder.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingPerformanceViewHolder.java
@@ -5,20 +5,18 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.pennapps.labs.pennmobile.R;
-
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class FlingPerformanceViewHolder extends RecyclerView.ViewHolder {
 
-    @Bind(R.id.flingview_image)
+    @BindView(R.id.flingview_image)
     public ImageView flingview_image;
-    @Bind(R.id.flingview_name)
+    @BindView(R.id.flingview_name)
     public TextView flingview_name;
-    @Bind(R.id.flingview_description)
+    @BindView(R.id.flingview_description)
     public TextView flingview_description;
-    @Bind(R.id.flingview_time)
+    @BindView(R.id.flingview_time)
     public TextView flingview_time;
 
     public FlingPerformanceViewHolder(View itemView) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrBuildingHolder.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrBuildingHolder.java
@@ -2,10 +2,9 @@ package com.pennapps.labs.pennmobile;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -15,8 +14,8 @@ import butterknife.ButterKnife;
 
 public class GsrBuildingHolder extends RecyclerView.ViewHolder {
 
-    @Bind(R.id.gsr_building_name) TextView gsrBuildingName;
-    @Bind(R.id.gsr_availability_in_building) RecyclerView recyclerView;
+    @BindView(R.id.gsr_building_name) TextView gsrBuildingName;
+    @BindView(R.id.gsr_availability_in_building) RecyclerView recyclerView;
 
     public GsrBuildingHolder(View itemView) {
         super(itemView);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.java
@@ -43,8 +43,9 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import io.fabric.sdk.android.Fabric;
 import rx.functions.Action1;
 
@@ -54,28 +55,24 @@ import rx.functions.Action1;
 
 public class GsrFragment extends Fragment {
 
+    @BindView(R.id.select_date) Button calendarButton;
+    @BindView(R.id.select_start_time) Button startButton;
+    @BindView(R.id.select_end_time) Button endButton;
+    @BindView(R.id.gsr_building_selection) Spinner gsrDropDown;
+    @BindView(R.id.instructions) TextView instructions;
+    private Unbinder unbinder;
+
+    private Labs mLabs;
 
     //list that holds all GSR rooms
     private Map<String, Integer> gsrHashMap = new HashMap<>();
     RecyclerView gsrRoomListRecylerView;
-
-    private Labs mLabs;
 
     ArrayList<String> gsrLocationsArray = new ArrayList<String>();
 
     ArrayList<GSRContainer> mGSRS = new ArrayList<GSRContainer>();
 
     DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss");
-
-    @Bind(R.id.select_date) Button calendarButton;
-    @Bind(R.id.select_start_time) Button startButton;
-    @Bind(R.id.select_end_time) Button endButton;
-    @Bind(R.id.gsr_building_selection) Spinner gsrDropDown;
-    @Bind(R.id.instructions) TextView instructions;
-
-
-
-
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -94,7 +91,7 @@ public class GsrFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_gsr, container, false);
 
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
 
 
         populateDropDownGSR();
@@ -282,6 +279,20 @@ public class GsrFragment extends Fragment {
         return v;
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.gsr);
+        ((MainActivity) getActivity()).setNav(R.id.nav_gsr);
+        populateDropDownGSR();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
+
     // Makes toast and performs GSR search
     // Called whenever user changes start/end time, date, or building
     public void searchForGSR() {
@@ -301,14 +312,6 @@ public class GsrFragment extends Fragment {
             getTimes(location, dateBooking, startTime, endTime);
 
         }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        getActivity().setTitle(R.string.gsr);
-        ((MainActivity) getActivity()).setNav(R.id.nav_gsr);
-        populateDropDownGSR();
     }
 
     public static String getCurrentTimeZoneOffset() {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrRoomHolder.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrRoomHolder.java
@@ -4,7 +4,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -14,11 +14,11 @@ import butterknife.ButterKnife;
 
 public class GsrRoomHolder extends RecyclerView.ViewHolder {
 
-    @Bind(R.id.gsr_room) LinearLayout gsrRoom;
-    @Bind(R.id.gsr_start_time) TextView gsrStartTime;
-    @Bind(R.id.gsr_end_time) TextView gsrEndTime;
-    @Bind(R.id.gsr_id)  TextView gsrId;
-    @Bind(R.id.locationId) TextView locationId;
+    @BindView(R.id.gsr_room) LinearLayout gsrRoom;
+    @BindView(R.id.gsr_start_time) TextView gsrStartTime;
+    @BindView(R.id.gsr_end_time) TextView gsrEndTime;
+    @BindView(R.id.gsr_id)  TextView gsrId;
+    @BindView(R.id.locationId) TextView locationId;
 
     public GsrRoomHolder(View itemView) {
         super(itemView);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/HomeScreenSettingsActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/HomeScreenSettingsActivity.java
@@ -20,10 +20,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import butterknife.BindView;
+import butterknife.ButterKnife;
 
 public class HomeScreenSettingsActivity extends AppCompatActivity {
 
-    private RecyclerView mRecyclerView;
+    @BindView(R.id.home_screen_settings_recyclerview) RecyclerView mRecyclerView;
+
     private Context mContext;
     private List<HomeScreenItem> mAllCategories;
     private SharedPreferences sharedPref;
@@ -32,6 +35,7 @@ public class HomeScreenSettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home_screen_settings);
+        ButterKnife.bind(this);
 
         // set up back button
         android.support.v7.app.ActionBar actionBar = getSupportActionBar();
@@ -47,7 +51,6 @@ public class HomeScreenSettingsActivity extends AppCompatActivity {
         mAllCategories.add(new HomeScreenItem("News", 5));
         mAllCategories.add(new HomeScreenItem("Spring Fling", 6));
 
-        mRecyclerView = (RecyclerView) findViewById(R.id.home_screen_settings_recyclerview);
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(mContext);
         mRecyclerView.setLayoutManager(linearLayoutManager);
         sharedPref = PreferenceManager.getDefaultSharedPreferences(mContext);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundryActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundryActivity.java
@@ -28,28 +28,28 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.fabric.sdk.android.Fabric;
 import rx.functions.Action1;
 
 public class LaundryActivity extends AppCompatActivity {
 
+    // views
+    @BindView(R.id.laundry_help_text)
+    TextView mTextView;
+    @BindView(R.id.loadingPanel)
+    RelativeLayout loadingPanel;
+    @BindView(R.id.no_results)
+    TextView no_results;
+    @BindView(R.id.favorite_laundry_list)
+    RecyclerView mRecyclerView;
+    private SwipeRefreshLayout swipeRefreshLayout;
+
     private Labs mLabs;
     private Context mContext;
 
     private SharedPreferences sp;
-
-    // views
-    @Bind(R.id.laundry_help_text)
-    TextView mTextView;
-    @Bind(R.id.loadingPanel)
-    RelativeLayout loadingPanel;
-    @Bind(R.id.no_results)
-    TextView no_results;
-    @Bind(R.id.favorite_laundry_list)
-    RecyclerView mRecyclerView;
-    private SwipeRefreshLayout swipeRefreshLayout;
 
     // list of favorite laundry rooms
     private ArrayList<LaundryRoom> laundryRooms = new ArrayList<>();
@@ -132,12 +132,6 @@ public class LaundryActivity extends AppCompatActivity {
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        ButterKnife.unbind(this);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundryBroadcastReceiver.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundryBroadcastReceiver.java
@@ -10,11 +10,11 @@ import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
 
-public class LaundryBroadcastReceiverNew extends BroadcastReceiver {
+public class LaundryBroadcastReceiver extends BroadcastReceiver {
 
     private int NOTIFICATION_ID;
 
-    public LaundryBroadcastReceiverNew() {
+    public LaundryBroadcastReceiver() {
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundrySettingsActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundrySettingsActivity.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import rx.functions.Action1;
 
@@ -31,13 +31,13 @@ public class LaundrySettingsActivity extends AppCompatActivity {
     private Labs mLabs;
     private Context mContext;
     private SwipeRefreshLayout mSwipeRefreshLayout;
-    @Bind(R.id.loadingPanel)
+    @BindView(R.id.loadingPanel)
     RelativeLayout loadingPanel;
-    @Bind(R.id.no_results)
+    @BindView(R.id.no_results)
     TextView no_results;
-    @Bind(R.id.laundry_building_expandable_list)
+    @BindView(R.id.laundry_building_expandable_list)
     ExpandableListView mExpandableListView;
-    @Bind(R.id.laundry_settings_help_layout)
+    @BindView(R.id.laundry_settings_help_layout)
     RelativeLayout mHelpLayout;
 
     private SharedPreferences sp;
@@ -194,6 +194,5 @@ public class LaundrySettingsActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        ButterKnife.unbind(this);
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
@@ -29,7 +29,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.functions.Action1;
 
 
@@ -42,7 +44,8 @@ import rx.functions.Action1;
  */
 public class MainFragment extends Fragment {
 
-    private RecyclerView mRecyclerView;
+    @BindView(R.id.home_screen_recyclerview) RecyclerView mRecyclerView;
+    Unbinder unbinder;
     private Context mContext;
     private List<HomeScreenItem> visibleCategories;
     private SharedPreferences sharedPref;
@@ -147,11 +150,10 @@ public class MainFragment extends Fragment {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_main_update, container, false);
-
+        unbinder = ButterKnife.bind(this, view);
         // settings
         setHasOptionsMenu(true);
 
-        mRecyclerView = (RecyclerView) view.findViewById(R.id.home_screen_recyclerview);
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(mContext);
         mRecyclerView.setLayoutManager(linearLayoutManager);
         return view;
@@ -194,7 +196,7 @@ public class MainFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 
     // get preferences

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.java
@@ -21,12 +21,14 @@ import java.util.HashMap;
 import java.util.List;
 
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class MenuFragment extends Fragment {
 
     TabAdapter pageAdapter;
     ViewPager pager;
 
+    private Unbinder unbinder;
     private DiningHall mDiningHall;
     private MainActivity mActivity;
 
@@ -123,7 +125,7 @@ public class MenuFragment extends Fragment {
         pager.setAdapter(pageAdapter);
 
         v.setBackgroundColor(Color.WHITE);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         ((MainActivity) getActivity()).addTabs(pageAdapter, pager, true);
         return v;
     }
@@ -148,7 +150,7 @@ public class MenuFragment extends Fragment {
         super.onDestroyView();
         getActivity().setTitle(R.string.dining);
         mActivity.removeTabs();
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
     @Override
     public void onDestroy() {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuTab.java
@@ -16,16 +16,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class MenuTab extends Fragment {
+
+    @BindView(R.id.menu_parent) LinearLayout menuParent;
+
     String meal;
     HashMap<String,List<String>> stationInfo = new HashMap<String,List<String>>();  //{station name: foods}
+    private Unbinder unbinder;
     private ArrayList<String> stations;
     private String name;
-    @Bind(R.id.menu_parent)
-    LinearLayout menuParent;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -53,7 +56,7 @@ public class MenuTab extends Fragment {
         elv.addFooterView(new View(elv.getContext()));
         elv.setAdapter(new MenuAdapter(getActivity(), stations, stationInfo));
         v.setBackgroundColor(Color.WHITE);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         return v;
     }
 
@@ -67,7 +70,7 @@ public class MenuTab extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         getActivity().setTitle(name);
-        ButterKnife.unbind(this);
+        unbinder.unbind();
     }
 
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NewsTab.java
@@ -12,17 +12,19 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ViewFlipper;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 
 public class NewsTab extends Fragment {
 
+    @BindView(R.id.flipper) ViewFlipper mFlipper;
+    @BindView(R.id.webViewNews) WebView mWebView;
+
+    private Unbinder unbinder;
     private String mUrl = "http://www.thedp.com/";
     static WebView currentWebView;
-    @Bind(R.id.webViewNews) WebView mWebView;
     private boolean newsLoaded;
-
-    @Bind(R.id.flipper) ViewFlipper mFlipper;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -39,7 +41,7 @@ public class NewsTab extends Fragment {
     @SuppressLint("SetJavaScriptEnabled")
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_news_tab, container, false);
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.setBackgroundColor(Color.argb(1, 0, 0, 0));
         if (!newsLoaded) {
@@ -95,6 +97,12 @@ public class NewsTab extends Fragment {
         if (isVisible) {
             currentWebView = mWebView;
         }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
     }
 
     /**

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
@@ -83,7 +83,7 @@ public class NsoFragment extends SearchFavoriteFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
+//        ButterKnife.unbind(this);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarFragment.java
@@ -10,7 +10,6 @@ import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.answers.Answers;
 import com.crashlytics.android.answers.ContentViewEvent;
 
-import butterknife.ButterKnife;
 import io.fabric.sdk.android.Fabric;
 
 /**
@@ -95,6 +94,5 @@ public class RegistrarFragment extends SearchFavoriteFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        ButterKnife.unbind(this);
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/RegistrarTab.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
@@ -32,6 +33,7 @@ import rx.functions.Action1;
  */
 public class RegistrarTab extends SearchFavoriteTab {
 
+    private Unbinder unbinder;
     private RegistrarAdapter mAdapter;
     private int frameID;
     public static CourseFragment[] fragments;
@@ -51,39 +53,20 @@ public class RegistrarTab extends SearchFavoriteTab {
         }
         frameLayout.setId(frameID);
 
-        ButterKnife.bind(this, v);
+        unbinder = ButterKnife.bind(this, v);
         mListView = (ListView) v.findViewById(android.R.id.list);
         initList();
         setBackButton(frameLayout);
         return v;
     }
 
-    private void setBackButton(FrameLayout frameLayout) {
-        frameLayout.setFocusableInTouchMode(true);
-        frameLayout.requestFocus();
-        frameLayout.setOnKeyListener(new View.OnKeyListener() {
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_DOWN && fragments[fav ? 1 : 0] != null) {
-                    backRemove(fav ? 1 : 0);
-                    return true;
-                }
-                if (((fav && fragments[0] != null && fragments[1] == null) || (!fav && fragments[0] == null && fragments[1] != null)) &&
-                        (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_DOWN)) {
-                    backRemove(fav ? 0 : 1);
-                }
-                return false;
-            }
-        });
-    }
-
-    public void backRemove(int id) {
-        FragmentManager fragmentManager = mActivity.getSupportFragmentManager();
-        fragmentManager.beginTransaction().remove(fragments[id]).commit();
-        fragments[id] = null;
-        if (fragments[0] == null && fragments[1] == null) {
-            mActivity.getActionBarToggle().setDrawerIndicatorEnabled(true);
-            mActivity.getActionBarToggle().syncState();
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (fav) {
+            search_instructions.setText(getString(R.string.search_no_fav));
+        } else {
+            search_instructions.setText(getString(R.string.registrar_instructions));
         }
     }
 
@@ -116,6 +99,41 @@ public class RegistrarTab extends SearchFavoriteTab {
     public void processQuery (String query) {
         super.processQuery(query);
         processRegistrarQuery(query);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbinder.unbind();
+    }
+
+    private void setBackButton(FrameLayout frameLayout) {
+        frameLayout.setFocusableInTouchMode(true);
+        frameLayout.requestFocus();
+        frameLayout.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_DOWN && fragments[fav ? 1 : 0] != null) {
+                    backRemove(fav ? 1 : 0);
+                    return true;
+                }
+                if (((fav && fragments[0] != null && fragments[1] == null) || (!fav && fragments[0] == null && fragments[1] != null)) &&
+                        (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_DOWN)) {
+                    backRemove(fav ? 0 : 1);
+                }
+                return false;
+            }
+        });
+    }
+
+    public void backRemove(int id) {
+        FragmentManager fragmentManager = mActivity.getSupportFragmentManager();
+        fragmentManager.beginTransaction().remove(fragments[id]).commit();
+        fragments[id] = null;
+        if (fragments[0] == null && fragments[1] == null) {
+            mActivity.getActionBarToggle().setDrawerIndicatorEnabled(true);
+            mActivity.getActionBarToggle().syncState();
+        }
     }
 
     private void processRegistrarQuery(String query) {
@@ -202,16 +220,6 @@ public class RegistrarTab extends SearchFavoriteTab {
             mActivity.closeKeyboard();
         } else {
             notFavoriteInit();
-        }
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        if (fav) {
-            search_instructions.setText(getString(R.string.search_no_fav));
-        } else {
-            search_instructions.setText(getString(R.string.registrar_instructions));
         }
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SearchFavoriteTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SearchFavoriteTab.java
@@ -10,7 +10,7 @@ import android.widget.TextView;
 import com.pennapps.labs.pennmobile.api.Labs;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import butterknife.Bind;
+import butterknife.BindView;
 
 
 /**
@@ -26,9 +26,9 @@ public abstract class SearchFavoriteTab extends ListFragment {
 
     private static final AtomicInteger sNextGeneratedId = new AtomicInteger(1);
 
-    protected @Bind(R.id.loadingPanel) RelativeLayout loadingPanel;
-    protected @Bind(R.id.no_results) TextView no_results;
-    protected @Bind(R.id.search_instructions) TextView search_instructions;
+    protected @BindView(R.id.loadingPanel) RelativeLayout loadingPanel;
+    protected @BindView(R.id.no_results) TextView no_results;
+    protected @BindView(R.id.search_instructions) TextView search_instructions;
 
 
     public SearchFavoriteTab() {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DiningAdapter.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.text.WordUtils;
 import java.util.Comparator;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
@@ -164,11 +164,11 @@ public class DiningAdapter extends ArrayAdapter<DiningHall> {
     }
 
     public static class ViewHolder {
-        @Bind(R.id.dining_hall_name) TextView hallNameTV;
-        @Bind(R.id.dining_hall_status) TextView hallStatus;
-        @Bind(R.id.dining_hall_open_meal) TextView openMeal;
-        @Bind(R.id.dining_hall_open_close) TextView openClose;
-        @Bind(R.id.dining_hall_menu_indicator) ImageView menuArrow;
+        @BindView(R.id.dining_hall_name) TextView hallNameTV;
+        @BindView(R.id.dining_hall_status) TextView hallStatus;
+        @BindView(R.id.dining_hall_open_meal) TextView openMeal;
+        @BindView(R.id.dining_hall_open_close) TextView openClose;
+        @BindView(R.id.dining_hall_menu_indicator) ImageView menuArrow;
         public DiningHall hall;
 
         public ViewHolder(View view, DiningHall hall) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DirectoryAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/DirectoryAdapter.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class DirectoryAdapter extends ArrayAdapter<Person> {
@@ -130,11 +130,11 @@ public class DirectoryAdapter extends ArrayAdapter<Person> {
     }
 
     static class ViewHolder {
-        @Bind(R.id.tv_person_name) TextView tvName;
-        @Bind(R.id.tv_person_affiliation) TextView tvAffiliation;
-        @Bind(R.id.tv_person_email) TextView tvEmail;
-        @Bind(R.id.star_contact) ToggleButton star;
-        @Bind(R.id.contact_icon) ImageView contact;
+        @BindView(R.id.tv_person_name) TextView tvName;
+        @BindView(R.id.tv_person_affiliation) TextView tvAffiliation;
+        @BindView(R.id.tv_person_email) TextView tvEmail;
+        @BindView(R.id.star_contact) ToggleButton star;
+        @BindView(R.id.contact_icon) ImageView contact;
 
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/FlingRecyclerViewAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/FlingRecyclerViewAdapter.java
@@ -40,7 +40,7 @@ public class FlingRecyclerViewAdapter extends RecyclerView.Adapter<FlingPerforma
     public void onBindViewHolder(FlingPerformanceViewHolder holder, int position) {
         if (position < getItemCount()) {
             FlingEvent flingEvent = data.get(position);
-            Picasso.with(context).load(flingEvent.imageUrl).into(holder.flingview_image);
+            Picasso.get().load(flingEvent.imageUrl).into(holder.flingview_image);
             holder.flingview_name.setText(flingEvent.name);
             holder.flingview_description.setText(flingEvent.description);
             DateTime startTime = timeFormatter.parseDateTime(flingEvent.startTime);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenAdapter.java
@@ -27,7 +27,7 @@ import com.pennapps.labs.pennmobile.classes.LaundryRoom;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -182,8 +182,7 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class CoursesViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
-        TextView titleTextView;
+        @BindView(R.id.home_screen_cardview_title) TextView titleTextView;
 
         public CoursesViewHolder(View view, Context context) {
             super(view);
@@ -201,9 +200,9 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class DiningViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
-        @Bind(R.id.home_screen_info)
+        @BindView(R.id.home_screen_info)
         TextView infoTextView;
 
         public DiningViewHolder(View view, Context context) {
@@ -222,7 +221,7 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class GSRViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
 
         public GSRViewHolder(View view, Context context) {
@@ -241,9 +240,9 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class LaundryViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
-        @Bind(R.id.home_screen_laundry_recyclerview)
+        @BindView(R.id.home_screen_laundry_recyclerview)
         RecyclerView laundryRecyclerView;
 
         public LaundryViewHolder(View view, Context context) {
@@ -263,7 +262,7 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class DirectoryViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
 
         public DirectoryViewHolder(View view, Context context) {
@@ -282,15 +281,15 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public class NewsViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
-        @Bind(R.id.home_screen_news_title)
+        @BindView(R.id.home_screen_news_title)
         TextView newsTitle;
-        @Bind(R.id.home_screen_news_source)
+        @BindView(R.id.home_screen_news_source)
         TextView newsSource;
-        @Bind(R.id.home_screen_news_date)
+        @BindView(R.id.home_screen_news_date)
         TextView newsDate;
-        @Bind(R.id.home_screen_news_image)
+        @BindView(R.id.home_screen_news_image)
         ImageView newsImage;
 
         public NewsViewHolder(View view, Context context) {
@@ -308,7 +307,7 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public class FlingViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
         Context context;
-        @Bind(R.id.home_screen_cardview_title)
+        @BindView(R.id.home_screen_cardview_title)
         TextView titleTextView;
 
         public FlingViewHolder(View view, Context context) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenSettingsAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenSettingsAdapter.java
@@ -21,7 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -146,9 +146,9 @@ public class HomeScreenSettingsAdapter extends RecyclerView.Adapter<HomeScreenSe
     public class CustomViewHolder extends RecyclerView.ViewHolder {
 
         Context context;
-        @Bind(R.id.home_screen_settings_switch)
+        @BindView(R.id.home_screen_settings_switch)
         Switch aSwitch;
-        @Bind(R.id.home_screen_category_name)
+        @BindView(R.id.home_screen_category_name)
         TextView titleTextView;
 
         public CustomViewHolder(View view, Context context) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryHomeAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryHomeAdapter.java
@@ -12,7 +12,7 @@ import com.pennapps.labs.pennmobile.classes.MachineList;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -57,11 +57,11 @@ public class LaundryHomeAdapter extends RecyclerView.Adapter<LaundryHomeAdapter.
 
     public class CustomViewHolder extends RecyclerView.ViewHolder {
 
-        @Bind(R.id.laundry_room_name_home)
+        @BindView(R.id.laundry_room_name_home)
         TextView roomNameTV;
-        @Bind(R.id.washer_availability_home)
+        @BindView(R.id.washer_availability_home)
         TextView washerAvailabilityTV;
-        @Bind(R.id.dryer_availability_home)
+        @BindView(R.id.dryer_availability_home)
         TextView dryerAvailabilityTV;
 
         public CustomViewHolder(View view) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryMachineAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryMachineAdapter.java
@@ -16,14 +16,14 @@ import android.widget.ImageView;
 import android.widget.Switch;
 import android.widget.TextView;
 
-import com.pennapps.labs.pennmobile.LaundryBroadcastReceiverNew;
+import com.pennapps.labs.pennmobile.LaundryBroadcastReceiver;
 import com.pennapps.labs.pennmobile.R;
 import com.pennapps.labs.pennmobile.classes.MachineDetail;
 
 import java.util.Collections;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -132,9 +132,9 @@ public class LaundryMachineAdapter extends RecyclerView.Adapter<LaundryMachineAd
 
         Context context;
         List<MachineDetail> machineDetails;
-        @Bind(R.id.laundry_machine_image_view)
+        @BindView(R.id.laundry_machine_image_view)
         ImageView machineView;
-        @Bind(R.id.min_left_time)
+        @BindView(R.id.min_left_time)
         TextView timeTextView;
         Switch alarmSwitch;
 
@@ -152,7 +152,7 @@ public class LaundryMachineAdapter extends RecyclerView.Adapter<LaundryMachineAd
 
         final int id = (mRoomName + mMachineType).hashCode() + machineId;
 
-        final Intent intent = new Intent(mContext, LaundryBroadcastReceiverNew.class);
+        final Intent intent = new Intent(mContext, LaundryBroadcastReceiver.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(mContext.getResources().getString(R.string.laundry_room_name), mRoomName);
         intent.putExtra(mContext.getResources().getString(R.string.laundry_machine_type), mMachineType);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryRoomAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/LaundryRoomAdapter.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -181,19 +181,19 @@ public class LaundryRoomAdapter extends RecyclerView.Adapter<LaundryRoomAdapter.
         Context mContext;
         ArrayList<LaundryRoom> mRooms;
 
-        @Bind(R.id.laundry_room_title)
+        @BindView(R.id.laundry_room_title)
         TextView title;
-        @Bind(R.id.fav_laundry_room_name)
+        @BindView(R.id.fav_laundry_room_name)
         TextView name;
-        @Bind(R.id.washer_availability)
+        @BindView(R.id.washer_availability)
         TextView washerAvailability;
-        @Bind(R.id.dryer_availability)
+        @BindView(R.id.dryer_availability)
         TextView dryerAvailability;
-        @Bind(R.id.laundry_washer_machine_list)
+        @BindView(R.id.laundry_washer_machine_list)
         RecyclerView washerRecyclerView;
-        @Bind(R.id.laundry_dryer_machine_list)
+        @BindView(R.id.laundry_dryer_machine_list)
         RecyclerView dryerRecyclerView;
-        @Bind(R.id.laundry_availability_chart)
+        @BindView(R.id.laundry_availability_chart)
         LineChart lineChart;
 
         public CustomViewHolder(View view, Context context, ArrayList<LaundryRoom> rooms, List<LaundryUsage> roomsData) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 /**
@@ -165,12 +165,12 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
     }
 
     static class ViewHolder {
-        @Bind(R.id.tv_event_name)
+        @BindView(R.id.tv_event_name)
         TextView tvName;
-        @Bind(R.id.tv_event_time) TextView tvTime;
-        @Bind(R.id.tv_event_description) TextView tvDescription;
-        @Bind(R.id.star_event) ToggleButton star;
-        @Bind(R.id.event_icon)
+        @BindView(R.id.tv_event_time) TextView tvTime;
+        @BindView(R.id.tv_event_description) TextView tvDescription;
+        @BindView(R.id.star_event) ToggleButton star;
+        @BindView(R.id.event_icon)
         ImageView event;
 
         public ViewHolder(View view) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/RegistrarAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/RegistrarAdapter.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class RegistrarAdapter extends ArrayAdapter<Course> {
@@ -116,12 +116,12 @@ public class RegistrarAdapter extends ArrayAdapter<Course> {
     }
 
     public static class ViewHolder {
-        @Bind(R.id.course_id_text) TextView courseId;
-        @Bind(R.id.course_instr_text) TextView courseInstr;
-        @Bind(R.id.course_title_text) TextView courseTitle;
-        @Bind(R.id.course_meeting_times) TextView courseTimes;
-        @Bind(R.id.star_course) ToggleButton star;
-        @Bind(R.id.course_activity) TextView courseActivity;
+        @BindView(R.id.course_id_text) TextView courseId;
+        @BindView(R.id.course_instr_text) TextView courseInstr;
+        @BindView(R.id.course_title_text) TextView courseTitle;
+        @BindView(R.id.course_meeting_times) TextView courseTimes;
+        @BindView(R.id.star_course) ToggleButton star;
+        @BindView(R.id.course_activity) TextView courseActivity;
         public Course course;
 
         public ViewHolder(View view, Course course) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/SupportAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/SupportAdapter.java
@@ -15,7 +15,7 @@ import com.pennapps.labs.pennmobile.classes.Person;
 
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class SupportAdapter extends ArrayAdapter<Person> {
@@ -72,9 +72,9 @@ public class SupportAdapter extends ArrayAdapter<Person> {
     }
 
     public static class ViewHolder {
-        @Bind(R.id.support_name) TextView name;
-        @Bind(R.id.support_phone) TextView phone;
-        @Bind(R.id.support_phone_icon) ImageView icon;
+        @BindView(R.id.support_name) TextView name;
+        @BindView(R.id.support_phone) TextView phone;
+        @BindView(R.id.support_phone_icon) ImageView icon;
 
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);

--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+repositories {
+    google()
+}
+buildscript {
+    repositories {
+        google()
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 23 22:16:35 EDT 2017
+#Thu Aug 16 00:29:26 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
There are several notable changes for the libraries we updated:

* [Butterknife](http://jakewharton.github.io/butterknife/) has changed the binding annotations from `@bind` to `@BindView` and changed how you unbind views. Also note that [you only have to manually unbind views in a `Fragment`](https://stackoverflow.com/questions/38015412/where-should-i-unbind-butterknife-8-x-x-in-a-viewholder), so it's unnecessary for `ViewHolder` and `Activity` classes.

* Google Maps API now uses `getMapAsync()` instead of `GetMap()` which has necessitated changes to `DiningInfoFragment` and `MapFragment` (the latter of which is not actually accessible in the app right now). Implementing `getMapAsync()` can be found [here](https://stackoverflow.com/questions/31371865/replace-getmap-with-getmapasync).