### PR TITLE
Nso relaunch with multidex

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -75,6 +75,6 @@ dependencies {
     androidTestImplementation 'org.testng:testng:6.14.3'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.github.ahorn:android-rss:v1.0-rc1'
+    implementation 'com.github.ahorn:android-rss:master-SNAPSHOT' // official release is several years old and is not thread-safe
 }
 

--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -35,6 +35,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 25
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled true
     }
     packagingOptions {
         pickFirst 'META-INF/LICENSE.txt'
@@ -47,6 +48,7 @@ dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.4@aar') {
         transitive = true
     }
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.google.maps:google-maps-services:0.2.10'
     implementation 'org.jsoup:jsoup:1.11.3'
     implementation 'com.android.support:percent:27.1.1'
@@ -67,11 +69,12 @@ dependencies {
     implementation 'com.android.support:customtabs:27.1.1'
     implementation 'com.android.support:recyclerview-v7:27.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.daimajia.swipelayout:library:1.2.0@aar'
+    implementation 'com.daimajia.swipelayout:library:1.2.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.testng:testng:6.14.3'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.android.support:cardview-v7:27.1.1'
+    implementation 'com.github.ahorn:android-rss:v1.0-rc1'
 }
 

--- a/PennMobile/src/main/AndroidManifest.xml
+++ b/PennMobile/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:required="true" />
 
     <application
+        android:name='android.support.multidex.MultiDexApplication'
         android:allowBackup="true"
         android:hardwareAccelerated="true"
         android:icon="@drawable/ic_launcher"

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/FlingFragment.java
@@ -87,7 +87,7 @@ public class FlingFragment extends Fragment {
     public void onResume() {
         super.onResume();
         getActivity().setTitle(R.string.spring_fling);
-        ((MainActivity) getActivity()).setNav(R.id.nav_fling);
+//        ((MainActivity) getActivity()).setNav(R.id.nav_fling);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/HomeScreenSettingsActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/HomeScreenSettingsActivity.java
@@ -49,7 +49,8 @@ public class HomeScreenSettingsActivity extends AppCompatActivity {
         mAllCategories.add(new HomeScreenItem("Laundry", 3));
         mAllCategories.add(new HomeScreenItem("Directory", 4));
         mAllCategories.add(new HomeScreenItem("News", 5));
-        mAllCategories.add(new HomeScreenItem("Spring Fling", 6));
+        mAllCategories.add(new HomeScreenItem("NSO", 6));
+//        mAllCategories.add(new HomeScreenItem("Spring Fling", 6));
 
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(mContext);
         mRecyclerView.setLayoutManager(linearLayoutManager);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.java
@@ -228,8 +228,11 @@ public class MainActivity extends AppCompatActivity {
                 Intent intent = new Intent(this, LaundryActivity.class);
                 startActivity(intent);
                 break;
-            case R.id.nav_fling:
-                fragment = new FlingFragment();
+//            case R.id.nav_fling:
+//                fragment = new FlingFragment();
+//                break;
+            case R.id.nav_nso:
+                fragment = new NsoFragment();
                 break;
             case R.id.nav_support:
                 fragment = new SupportFragment();

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
@@ -125,28 +125,29 @@ public class MainFragment extends Fragment {
         if (numVisibleCategories == 0) {
 
             DateTime today = new DateTime();
+
             DateTime nsoStart = new DateTime(2018, 8, 15, 0, 0, 0, 0);
             DateTime nsoEnd = new DateTime(2018, 10, 15, 0, 0, 0, 0);
             Interval nsoDates = new Interval(nsoStart, nsoEnd);
+
+//            DateTime flingStart = new DateTime(2019, 4, 10, 0, 0, 0, 0);
+//            DateTime flingEnd = new DateTime(2019, 4, 15, 0, 0, 0, 0);
+//            Interval flingDates = new Interval(flingStart, flingEnd);
+
+            // default: dining, laundry, GSR
+            visibleCategories.add(mAllCategories.get(1));
+            visibleCategories.add(mAllCategories.get(3));
+            visibleCategories.add(mAllCategories.get(2));
 
             // check if today is part of NSO dates - if so, add NSO to home page
             if (nsoDates.contains(today)) {
                 visibleCategories.add(mAllCategories.get(6));
             }
 
-//            DateTime flingStart = new DateTime(2019, 4, 10, 0, 0, 0, 0);
-//            DateTime flingEnd = new DateTime(2019, 4, 15, 0, 0, 0, 0);
-//            Interval flingDates = new Interval(flingStart, flingEnd);
-//
 //            // check if today is part of Fling dates - if so, add Fling to home page
 //            if (flingDates.contains(today)) {
 //                visibleCategories.add(mAllCategories.get(6));
 //            }
-
-            // default: dining, laundry, GSR
-            visibleCategories.add(mAllCategories.get(1));
-            visibleCategories.add(mAllCategories.get(3));
-            visibleCategories.add(mAllCategories.get(2));
         }
 
         // update home screen

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainFragment.java
@@ -97,7 +97,8 @@ public class MainFragment extends Fragment {
         mAllCategories.add(new HomeScreenItem("Laundry", 3));
         mAllCategories.add(new HomeScreenItem("Directory", 4));
         mAllCategories.add(new HomeScreenItem("News", 5));
-        mAllCategories.add(new HomeScreenItem("Spring Fling", 6));
+//        mAllCategories.add(new HomeScreenItem("Spring Fling", 6));
+        mAllCategories.add(new HomeScreenItem("NSO", 6));
 
         // determine which categories are visible
         int numVisibleCategories = 0;
@@ -124,14 +125,23 @@ public class MainFragment extends Fragment {
         if (numVisibleCategories == 0) {
 
             DateTime today = new DateTime();
-            DateTime flingStart = new DateTime(2018, 4, 10, 0, 0, 0, 0);
-            DateTime flingEnd = new DateTime(2018, 4, 15, 0, 0, 0, 0);
-            Interval flingDates = new Interval(flingStart, flingEnd);
+            DateTime nsoStart = new DateTime(2018, 8, 15, 0, 0, 0, 0);
+            DateTime nsoEnd = new DateTime(2018, 10, 15, 0, 0, 0, 0);
+            Interval nsoDates = new Interval(nsoStart, nsoEnd);
 
-            // check if today is part of Fling dates - if so, add Fling to home page
-            if (flingDates.contains(today)) {
+            // check if today is part of NSO dates - if so, add NSO to home page
+            if (nsoDates.contains(today)) {
                 visibleCategories.add(mAllCategories.get(6));
             }
+
+//            DateTime flingStart = new DateTime(2019, 4, 10, 0, 0, 0, 0);
+//            DateTime flingEnd = new DateTime(2019, 4, 15, 0, 0, 0, 0);
+//            Interval flingDates = new Interval(flingStart, flingEnd);
+//
+//            // check if today is part of Fling dates - if so, add Fling to home page
+//            if (flingDates.contains(today)) {
+//                visibleCategories.add(mAllCategories.get(6));
+//            }
 
             // default: dining, laundry, GSR
             visibleCategories.add(mAllCategories.get(1));

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
@@ -8,7 +8,12 @@ import android.support.v4.app.FragmentManager;
 import android.support.v7.preference.PreferenceManager;
 import android.view.View;
 
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.answers.Answers;
+import com.crashlytics.android.answers.ContentViewEvent;
+
 import butterknife.ButterKnife;
+import io.fabric.sdk.android.Fabric;
 
 /**
  * Created by Jason on 8/6/2016.
@@ -66,6 +71,16 @@ public class NsoFragment extends SearchFavoriteFragment {
     @Override
     protected int searchCount() {
         return PreferenceManager.getDefaultSharedPreferences(mActivity).getInt(getString(R.string.nso_search_count), -1);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Fabric.with(getContext(), new Crashlytics());
+        Answers.getInstance().logContentView(new ContentViewEvent()
+                .putContentName("NSO")
+                .putContentType("App Feature")
+                .putContentId("8"));
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoFragment.java
@@ -72,7 +72,7 @@ public class NsoFragment extends SearchFavoriteFragment {
     public void onResume() {
         super.onResume();
         getActivity().setTitle(R.string.nso);
-//        mActivity.setNav(R.id.nav_nso);
+        mActivity.setNav(R.id.nav_nso);
     }
 
     @Override

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoTab.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NsoTab.java
@@ -1,19 +1,29 @@
 package com.pennapps.labs.pennmobile;
 
-//import android.support.annotation.NonNull;
-//import android.support.v7.preference.PreferenceManager;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.preference.PreferenceManager;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
 
 import com.pennapps.labs.pennmobile.adapters.NsoAdapter;
 
-//import org.mcsoxford.rss.RSSItem;
-//import org.mcsoxford.rss.RSSReader;
-//import org.mcsoxford.rss.RSSReaderException;
+import org.mcsoxford.rss.RSSItem;
+import org.mcsoxford.rss.RSSReader;
+import org.mcsoxford.rss.RSSReaderException;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
 import rx.Observable;
 import rx.Subscriber;
 
@@ -24,17 +34,19 @@ public class NsoTab extends SearchFavoriteTab {
 
     private NsoAdapter adapter;
 
-    private List<String> fullList; //List<RSSItem>
+    private Unbinder unbinder;
 
-//    @Override
-//    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-//        super.onCreateView(inflater, container, savedInstanceState);
-//        View v = inflater.inflate(R.layout.fragment_search_favorite_tab, container, false);
-//        ButterKnife.bind(this, v);
-//        mListView = (ListView) v.findViewById(android.R.id.list);
-//        initList();
-//        return v;
-//    }
+    private List<RSSItem> fullList;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+        View v = inflater.inflate(R.layout.fragment_search_favorite_tab, container, false);
+        unbinder =  ButterKnife.bind(this, v);
+        mListView = (ListView) v.findViewById(android.R.id.list);
+        initList();
+        return v;
+    }
 
     @Override
     public void processQuery (String query) {
@@ -43,14 +55,14 @@ public class NsoTab extends SearchFavoriteTab {
     }
 
     private void processNsoQuery(final String query) {
-        Observable<List<String>> obs = Observable.create(new Observable.OnSubscribe<List<String>>() { //List<String>
+        Observable<List<RSSItem>> obs = Observable.create(new Observable.OnSubscribe<List<RSSItem>>() {
             @Override
-            public void call(Subscriber<? super List<String>> subscriber) { //List<RSSItem>
+            public void call(Subscriber<? super List<RSSItem>> subscriber) {
                 subscriber.onNext(getRSSFeed(query));
                 subscriber.onCompleted();
             }
         });
-        obs.subscribe(new Subscriber<List<String>>() { //List<RSSItem>
+        obs.subscribe(new Subscriber<List<RSSItem>>() {
             @Override
             public void onCompleted() {
                 if (adapter == null) {
@@ -71,92 +83,90 @@ public class NsoTab extends SearchFavoriteTab {
             }
 
             @Override
-            public void onNext(List<String> rssItems) { //List<RSSItem>
+            public void onNext(List<RSSItem> rssItems) {
                 if (rssItems.isEmpty()) {
                     adapter = null;
                 } else {
-//                    adapter = new NsoAdapter(mActivity, rssItems);
+                    adapter = new NsoAdapter(mActivity, rssItems);
                 }
             }
         });
     }
 
-//    @NonNull
-    private List<String> getRSSFeed(String query) { //List<RSSItem>
-        return new LinkedList<>();
-//        try {
-//            List<RSSItem> items;
-//            if (fullList == null) {
-//                RSSReader reader = new RSSReader();
-//                String uri = "http://api.pennlabs.org/nso";
-//                items = reader.load(uri).getItems();
-//                fullList = new ArrayList<>(items);
-//            } else {
-//                items = new ArrayList<>(fullList);
-//            }
-//            if (query.isEmpty()) {
-//                return items;
-//            }
-//            List<RSSItem> answer = new LinkedList<>();
-//            for (RSSItem item : items) {
-//                if (item.getTitle().contains(query)) {
-//                    answer.add(item);
-//                }
-//            }
-//            return answer;
-//        } catch (RSSReaderException e) {
-//            Log.d("NSO", "error reading rss", e);
-//            return new LinkedList<>();
-//        }
+    @NonNull
+    private List<RSSItem> getRSSFeed(String query) {
+        try {
+            List<RSSItem> items;
+            if (fullList == null) {
+                RSSReader reader = new RSSReader();
+                String uri = "http://api.pennlabs.org/nso";
+                items = reader.load(uri).getItems();
+                fullList = new ArrayList<>(items);
+            } else {
+                items = new ArrayList<>(fullList);
+            }
+            if (query.isEmpty()) {
+                return items;
+            }
+            List<RSSItem> answer = new LinkedList<>();
+            for (RSSItem item : items) {
+                if (item.getTitle().contains(query)) {
+                    answer.add(item);
+                }
+            }
+            return answer;
+        } catch (RSSReaderException e) {
+            Log.d("NSO", "error reading rss", e);
+            return new LinkedList<>();
+        }
     }
 
 
     @Override
     public void initList() {
-//        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(mActivity);
-//        Set<String> starred = sp.getStringSet(getString(R.string.search_nso_star), new HashSet<String>());
-//        if (loadingPanel.getVisibility() == View.VISIBLE) {
-//            loadingPanel.setVisibility(View.GONE);
-//        }
-//        if (mListView.getVisibility() == View.GONE) {
-//            mListView.setVisibility(View.VISIBLE);
-//        }
-//        if (no_results.getVisibility() == View.VISIBLE) {
-//            no_results.setVisibility(View.GONE);
-//        }
-//        if (search_instructions.getVisibility() == View.VISIBLE) {
-//            search_instructions.setVisibility(View.GONE);
-//        }
-//        List<RSSItem> items = getRSSFeed("");
-//        if (fav) {
-//            // need to improve runtime later (worst case O(n^2) smh
-//            List<RSSItem> favItems = new LinkedList<>();
-//            for (String s : starred) {
-//                String details = sp.getString(s + getString(R.string.search_nso_star), "");
-//                if (!details.isEmpty()) {
-//                    for (RSSItem item : items) {
-//                        if (item.getTitle().equals(details)) {
-//                            favItems.add(item);
-//                            break;
-//                        }
-//                    }
-//                }
-//            }
-//            items = favItems;
-//        }
-//        adapter = new NsoAdapter(mActivity, items);
-//        mListView.setAdapter(adapter);
-//        mActivity.closeKeyboard();
-
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(mActivity);
+        Set<String> starred = sp.getStringSet(getString(R.string.search_nso_star), new HashSet<String>());
+        if (loadingPanel.getVisibility() == View.VISIBLE) {
+            loadingPanel.setVisibility(View.GONE);
+        }
+        if (mListView.getVisibility() == View.GONE) {
+            mListView.setVisibility(View.VISIBLE);
+        }
+        if (no_results.getVisibility() == View.VISIBLE) {
+            no_results.setVisibility(View.GONE);
+        }
+        if (search_instructions.getVisibility() == View.VISIBLE) {
+            search_instructions.setVisibility(View.GONE);
+        }
+        List<RSSItem> items = getRSSFeed("");
+        if (fav) {
+            // need to improve runtime later (worst case O(n^2) smh
+            List<RSSItem> favItems = new LinkedList<>();
+            for (String s : starred) {
+                String details = sp.getString(s + getString(R.string.search_nso_star), "");
+                if (!details.isEmpty()) {
+                    for (RSSItem item : items) {
+                        if (item.getTitle().equals(details)) {
+                            favItems.add(item);
+                            break;
+                        }
+                    }
+                }
+            }
+            items = favItems;
+        }
+        adapter = new NsoAdapter(mActivity, items);
+        mListView.setAdapter(adapter);
+        mActivity.closeKeyboard();
     }
 
-//    @Override
-//    public void onActivityCreated(Bundle savedInstanceState) {
-//        super.onActivityCreated(savedInstanceState);
-//        if (fav) {
-//            search_instructions.setText(getString(R.string.search_no_fav));
-//        } else {
-//            search_instructions.setText(getString(R.string.nso_instructions));
-//        }
-//    }
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (fav) {
+            search_instructions.setText(getString(R.string.search_no_fav));
+        } else {
+            search_instructions.setText(getString(R.string.nso_instructions));
+        }
+    }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SearchFavoriteFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SearchFavoriteFragment.java
@@ -91,7 +91,7 @@ public abstract class SearchFavoriteFragment extends ListFragment {
         viewPager = (ViewPager) v.findViewById(R.id.pager);
         tabAdapter = getAdapter();
         viewPager.setAdapter(tabAdapter);
-        viewPager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
             public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeScreenAdapter.java
@@ -19,6 +19,7 @@ import com.pennapps.labs.pennmobile.FlingFragment;
 import com.pennapps.labs.pennmobile.GsrFragment;
 import com.pennapps.labs.pennmobile.LaundryActivity;
 import com.pennapps.labs.pennmobile.NewsFragment;
+import com.pennapps.labs.pennmobile.NsoFragment;
 import com.pennapps.labs.pennmobile.R;
 import com.pennapps.labs.pennmobile.RegistrarFragment;
 import com.pennapps.labs.pennmobile.classes.HomeScreenCell;
@@ -91,8 +92,10 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 view = LayoutInflater.from(mContext).inflate(R.layout.home_cardview_card_news, parent, false);
                 return new NewsViewHolder(view, mContext);
             case 6:
-                view = LayoutInflater.from(mContext).inflate(R.layout.home_fling_card, parent, false);
-                return new FlingViewHolder(view, mContext);
+                view = LayoutInflater.from(mContext).inflate(R.layout.home_nso_card, parent, false);
+                return new NsoViewHolder(view, mContext);
+//                view = LayoutInflater.from(mContext).inflate(R.layout.home_fling_card, parent, false);
+//                return new FlingViewHolder(view, mContext);
             default:
                 view = LayoutInflater.from(mContext).inflate(R.layout.home_cardview_empty_item, parent, false);
                 return new EmptyViewHolder(view, mContext);
@@ -101,7 +104,7 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Override
     public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position) {
-        // In order: Courses, Dining, GSR Booking, Laundry, Map, News
+        // In order: Courses, Dining, GSR Booking, Laundry, Directory, News, Fling/NSO
         switch (holder.getItemViewType()) {
             case 0:
                 CoursesViewHolder coursesViewHolder = (CoursesViewHolder) holder;
@@ -171,9 +174,12 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 */
                 break;
             case 6:
-                FlingViewHolder flingViewHolder = (FlingViewHolder) holder;
-                String flingTitle = mCategories.get(position).getName();
-                flingViewHolder.titleTextView.setText(flingTitle);
+                NsoViewHolder nsoViewHolder = (NsoViewHolder) holder;
+                String nsoTitle = mCategories.get(position).getName();
+                nsoViewHolder.titleTextView.setText(nsoTitle);
+//                FlingViewHolder flingViewHolder = (FlingViewHolder) holder;
+//                String flingTitle = mCategories.get(position).getName();
+//                flingViewHolder.titleTextView.setText(flingTitle);
                 break;
         }
     }
@@ -320,6 +326,24 @@ public class HomeScreenAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         @Override
         public void onClick(View view) {
             fragmentTransact(new FlingFragment());
+        }
+    }
+
+    public class NsoViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+        Context context;
+        @BindView(R.id.home_screen_cardview_title)
+        TextView titleTextView;
+
+        public NsoViewHolder(View view, Context context) {
+            super(view);
+            ButterKnife.bind(this, view);
+            this.context = context;
+            view.setOnClickListener(this);
+        }
+
+        @Override
+        public void onClick(View view) {
+            fragmentTransact(new NsoFragment());
         }
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
@@ -11,10 +11,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
-import com.daimajia.swipe.SwipeLayout;
 import com.pennapps.labs.pennmobile.R;
 
-// import org.mcsoxford.rss.RSSItem;
+import org.mcsoxford.rss.RSSItem;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -30,11 +29,11 @@ import butterknife.ButterKnife;
 /**
  * Created by Jason on 8/11/2016.
  */
-public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
+public class NsoAdapter extends ArrayAdapter<RSSItem> {
     private final LayoutInflater inflater;
     private Context mContext;
 
-    public NsoAdapter(Context context, List<String> list) { //List<RSSItem> list
+    public NsoAdapter(Context context, List<RSSItem> list) {
         super(context, R.layout.nso_list_item, list);
         inflater = LayoutInflater.from(context);
         mContext = context;
@@ -51,11 +50,7 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
             view.setTag(holder);
         }
 
-        SwipeLayout swipeLayout = (SwipeLayout) view.findViewById(R.id.nso_swipe);
-        swipeLayout.setShowMode(SwipeLayout.ShowMode.PullOut);
-        swipeLayout.addDrag(SwipeLayout.DragEdge.Right, view.findViewById(R.id.nso_swipe_drawer));
-
-        final String item = getItem(position); //RSSItem item
+        final RSSItem item = getItem(position);
 
         holder.event.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -65,19 +60,19 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
             }
         });
 
-        holder.tvName.setText(item); //setText(getTitleName(item))
-        holder.tvTime.setText(item);
-//        try {
-//            holder.tvTime.setText(getEventTime(item));
-//        } catch (ParseException e) {
-//            //ignore
+        holder.tvName.setText(getTitleName(item));
+
+        try {
+            holder.tvTime.setText(getEventTime(item));
+        } catch (ParseException e) {
+            //ignore
 //            Log.d("NSO", "parse error:", e);
-//        }
-        holder.tvDescription.setText(item); //setText(getDescription(item))
+        }
+        holder.tvDescription.setText(getDescription(item));
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(view.getContext());
         Set<String> starredContacts = sharedPref.getStringSet(mContext.getResources().getString(R.string.search_nso_star), new HashSet<String>());
-        holder.star.setChecked(starredContacts.contains(item)); //contains(item.getTitle())
+        holder.star.setChecked(starredContacts.contains(item.getTitle()));
         holder.star.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -87,7 +82,7 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
                 SharedPreferences.Editor editedPreferences = sharedPref.edit();
                 ToggleButton star = (ToggleButton) v;
                 boolean starred = star.isChecked();
-                String currentTitle = item; //item.getTitle()
+                String currentTitle = item.getTitle();
                 if (starred) {
                     if (currentTitle != null) {
                         starredContacts.add(currentTitle);
@@ -113,8 +108,8 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
      * @param item the item to be parsed
      * @return the string to be displayed as the title
      */
-    public static String getTitleName(String item) { //RSSItem item
-        String title = item; //item.getTitle()
+    public static String getTitleName(RSSItem item) {
+        String title = item.getTitle();
         title = title.substring(title.indexOf("\">")+2);
         title = title.substring(0, title.indexOf("</a>"));
         while (title.contains("&amp;")) {
@@ -129,8 +124,8 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
      * @return the string to be displayed as the time
      * @throws ParseException the exception thrown if couldn't parse correctly.
      */
-    private String getEventTime(String item) throws ParseException{ //RSSItem item
-        String time = item; //item.getTitle()
+    private String getEventTime(RSSItem item) throws ParseException {
+        String time = item.getTitle();
         time = time.substring(time.indexOf("event/") + 6);
         time = time.substring(0, time.indexOf("/"));
         String starttime = time.substring(0, 17);
@@ -155,8 +150,8 @@ public class NsoAdapter extends ArrayAdapter<String> { //ArrayAdapter<RSSItem>
      * @param item the item to be parsed
      * @return the string to be displayed as description
      */
-    private String getDescription(String item) { //RSSItem item
-        String description = item; //item.getDescription()
+    private String getDescription(RSSItem item) {
+        String description = item.getDescription();
         description = description.substring(3);
         while (description.contains("&amp;")) {
             description = description.replace("&amp;", "&");

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/NsoAdapter.java
@@ -7,7 +7,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
@@ -51,14 +50,6 @@ public class NsoAdapter extends ArrayAdapter<RSSItem> {
         }
 
         final RSSItem item = getItem(position);
-
-        holder.event.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                //to be implemented
-
-            }
-        });
 
         holder.tvName.setText(getTitleName(item));
 
@@ -115,6 +106,9 @@ public class NsoAdapter extends ArrayAdapter<RSSItem> {
         while (title.contains("&amp;")) {
             title = title.replace("&amp;", "&");
         }
+        while (title.contains("&#039;")) {
+            title = title.replace("&#039;", "'");
+        }
         return title;
     }
 
@@ -132,14 +126,14 @@ public class NsoAdapter extends ArrayAdapter<RSSItem> {
         Calendar cal = Calendar.getInstance();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-HHmmss", Locale.US);
         cal.setTime(sdf.parse(starttime));
-        SimpleDateFormat out = new SimpleDateFormat("EEE M/dd K:mm a", Locale.US);
+        SimpleDateFormat out = new SimpleDateFormat("EEE M/dd h:mm a", Locale.US);
         String answer = out.format(cal.getTime());
         if (time.length() < 18) {
             return answer;
         }
         answer += " – ";
         String endtime = time.substring(18);
-        out = new SimpleDateFormat("K:mm a", Locale.US);
+        out = new SimpleDateFormat("h:mm a", Locale.US);
         cal.setTime(sdf.parse(endtime));
         answer += out.format(cal.getTime());
         return answer;
@@ -152,9 +146,14 @@ public class NsoAdapter extends ArrayAdapter<RSSItem> {
      */
     private String getDescription(RSSItem item) {
         String description = item.getDescription();
-        description = description.substring(3);
+        if (description.length() >= 4) {
+            description = description.substring(3);
+        }
         while (description.contains("&amp;")) {
             description = description.replace("&amp;", "&");
+        }
+        while (description.contains("&#039;")) {
+            description = description.replace("&#039;", "'");
         }
         return description;
     }
@@ -165,8 +164,6 @@ public class NsoAdapter extends ArrayAdapter<RSSItem> {
         @BindView(R.id.tv_event_time) TextView tvTime;
         @BindView(R.id.tv_event_description) TextView tvDescription;
         @BindView(R.id.star_event) ToggleButton star;
-        @BindView(R.id.event_icon)
-        ImageView event;
 
         public ViewHolder(View view) {
             ButterKnife.bind(this, view);

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/Serializer.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/Serializer.java
@@ -177,6 +177,7 @@ public class Serializer {
             }.getType());
         }
     }
+
     // fling events
     public static class FlingEventSerializer implements  JsonDeserializer<List<FlingEvent>> {
 
@@ -188,6 +189,7 @@ public class Serializer {
             }.getType());
         }
     }
+
     // home page
     public static class HomePageSerializer implements JsonDeserializer<List<HomeScreenCell>> {
         @Override

--- a/PennMobile/src/main/res/layout/home_nso_card.xml
+++ b/PennMobile/src/main/res/layout/home_nso_card.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="8dp"
+    android:paddingRight="8dp"
+    android:paddingTop="8dp"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        card_view:cardCornerRadius="8dp"
+        card_view:cardElevation="2dp"
+        card_view:cardUseCompatPadding="true">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="16dp">
+
+            <ImageView
+                android:id="@+id/home_screen_cardview_icon"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_marginRight="16dp"
+                android:src="@drawable/ic_nso" />
+
+            <TextView
+                android:layout_toRightOf="@id/home_screen_cardview_icon"
+                android:id="@+id/home_screen_cardview_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                tools:text="NSO" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:src="@drawable/ic_chevron_right_black_24dp" />
+
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+</LinearLayout>

--- a/PennMobile/src/main/res/layout/nso_list_item.xml
+++ b/PennMobile/src/main/res/layout/nso_list_item.xml
@@ -1,90 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.daimajia.swipe.SwipeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/nso_swipe"
+    android:id="@+id/nso_item_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
 
-    <RelativeLayout
+    <TextView
+        android:id="@+id/tv_event_name"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:id="@+id/nso_swipe_drawer"
-        android:background="#E7E7E7">
+        android:layout_height="wrap_content"
+        android:paddingBottom="2dp"
+        android:textColor="@color/text_color"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        tools:text="Getting Around Penn: Guided Tours of Local Businesses" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="17dp"
-            android:contentDescription="@string/add_event"
-            android:scaleType="fitXY"
-            android:src="@drawable/ic_event_black_24dp"
-            android:tint="@color/secondary_text"
-            android:layout_centerInParent="true"
-            android:id="@+id/event_icon"
-            />
-    </RelativeLayout>
+    <ToggleButton
+        android:id="@+id/star_event"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_marginBottom="10dp"
+        android:background="@drawable/star"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:textOff=""
+        android:textOn=""
 
-    <RelativeLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:paddingBottom="@dimen/activity_vertical_margin" >
+        android:tint="@color/star_color_off" />
 
-        <TextView
-            tools:text="Getting Around Penn: Guided Tours of Local Businesses"
-            android:id="@+id/tv_event_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="2dp"
-            android:textSize="20sp"
-            android:textStyle="bold"
-            android:textColor="@color/text_color" />
+    <TextView
+        android:id="@+id/tv_event_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tv_event_name"
+        android:layout_marginRight="32dp"
+        android:paddingBottom="2dp"
+        android:textColor="@color/text_color"
+        android:textSize="16sp"
+        tools:text="2016-08-23 16:30:00- 2016-08-23 18:30:00" />
 
-        <ToggleButton
-            android:id="@+id/star_event"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:layout_marginBottom="10dp"
-            android:textOn=""
-            android:textOff=""
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:tint="@color/star_color_off"
+    <TextView
+        android:id="@+id/tv_event_description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tv_event_time"
+        android:layout_toLeftOf="@id/star_event"
+        android:paddingBottom="2dp"
+        android:textColor="@color/secondary_text"
+        android:textSize="16sp"
+        tools:text="Sign up here to take a trip to bank and phone companies with the ePHINS and iPHINS to get settled in Philadelphia." />
 
-            android:background="@drawable/star" />
-
-        <TextView
-            tools:text="2016-08-23 16:30:00- 2016-08-23 18:30:00"
-            android:id="@+id/tv_event_time"
-            android:layout_below="@+id/tv_event_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="32dp"
-            android:paddingBottom="2dp"
-            android:textSize="16sp"
-            android:textColor="@color/text_color" />
-
-        <TextView
-            tools:text="Sign up here to take a trip to bank and phone companies with the ePHINS and iPHINS to get settled in Philadelphia."
-            android:id="@+id/tv_event_description"
-            android:layout_below="@+id/tv_event_time"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toLeftOf="@id/star_event"
-            android:paddingBottom="2dp"
-            android:textSize="16sp"
-            android:textColor="@color/secondary_text" />
-
-    </RelativeLayout>
-
-
-
-
-</com.daimajia.swipe.SwipeLayout>
+</RelativeLayout>

--- a/PennMobile/src/main/res/menu/navigation_drawer_items.xml
+++ b/PennMobile/src/main/res/menu/navigation_drawer_items.xml
@@ -41,15 +41,15 @@
             android:icon="@drawable/ic_announcement"
             android:title="@string/news"/>
 
-        <item
-            android:id="@+id/nav_fling"
-            android:icon="@drawable/ic_event_black_24dp"
-            android:title="@string/spring_fling"/>
-
         <!--<item-->
-            <!--android:id="@+id/nav_nso"-->
+            <!--android:id="@+id/nav_fling"-->
             <!--android:icon="@drawable/ic_event_black_24dp"-->
-            <!--android:title="@string/nso"/>-->
+            <!--android:title="@string/spring_fling"/>-->
+
+        <item
+            android:id="@+id/nav_nso"
+            android:icon="@drawable/ic_event_black_24dp"
+            android:title="@string/nso"/>
 
         <item
             android:id="@+id/nav_support"


### PR DESCRIPTION
Changes:

* App is now multidex because there are over 64K methods
* Fling feature no longer accessible, NSO feature shown by default
* NSO network calls are no longer blocking the main thread
* Use `Single` instead of `Observable` for cleaner code
* Remove swipe layout from NSO event items (swiping left would show a dummy button that theoretically lets users add the event to their calendars in a style that looks like [this](https://camo.githubusercontent.com/183f464b177ffa9d0b35f396796ec64f37ce87db/687474703a2f2f7777312e73696e61696d672e636e2f6d773639302f36313064633033346a7731656a6f7175696476767367323038693036333075342e676966)) because it makes user navigation annoying