### PR TITLE
Fixed crashes caused by not handling RxJava onError

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/CourseFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/CourseFragment.java
@@ -178,6 +178,10 @@ public class CourseFragment extends Fragment implements OnMapReadyCallback {
                                 drawMarker(buildings.get(0).getLatLng(), meetingLocation);
                             }
                         }
+                    }, new Action1<Throwable>() {
+                        @Override
+                        public void call(Throwable throwable) {
+                        }
                     });
         }
     }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningInfoFragment.java
@@ -100,6 +100,10 @@ public class DiningInfoFragment extends Fragment implements OnMapReadyCallback {
                                 drawMarker(buildings.get(0).getLatLng());
                             }
                         }
+                    }, new Action1<Throwable>() {
+                        @Override
+                        public void call(Throwable throwable) {
+                        }
                     });
         }
     }


### PR DESCRIPTION
This should fix the majority of the ambiguous "Exception thrown on Scheduler.Worker thread. Add `onError` handling" crashes that we've seen on Fabric.