### PR TITLE
fixed booking for durations >30

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
@@ -318,10 +318,7 @@ class GsrFragment : Fragment() {
                 val stringStartTime = startTime.toString(timeFormatter)
                 val stringEndTime = endTime.toString(timeFormatter)
                 val start = startingSlot.startTime ?: ""
-                /* changed startingSlot to endingSlot in the line below
-                 * to account for duration when booking GSRs
-                 * - Ali Krema, 09/25/2022
-                 */
+                //note that end uses ending slot to account for 30+ min bookings
                 val end = endingSlot.endTime ?: ""
                 val gsrName = gsrRoom.name ?: ""
                 val gsrRoomId = gsrRoom.room_id ?: 0

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
@@ -293,6 +293,7 @@ class GsrFragment : Fragment() {
                 val endString = currSlot.endTime
 
                 if (startString != null && endString != null) {
+
                     val endTime = gsrSlotFormatter.parseDateTime(endString)
                     if (endTime.isAfter(selectedDateTime)) {
                         availableSlotsAfterSelectedTime.add(currSlot)
@@ -317,7 +318,11 @@ class GsrFragment : Fragment() {
                 val stringStartTime = startTime.toString(timeFormatter)
                 val stringEndTime = endTime.toString(timeFormatter)
                 val start = startingSlot.startTime ?: ""
-                val end = startingSlot.endTime ?: ""
+                /* changed startingSlot to endingSlot in the line below
+                 * to account for duration when booking GSRs
+                 * - Ali Krema, 09/25/2022
+                 */
+                val end = endingSlot.endTime ?: ""
                 val gsrName = gsrRoom.name ?: ""
                 val gsrRoomId = gsrRoom.room_id ?: 0
                 insertGSRSlot(gsrName, "$stringStartTime-$stringEndTime",

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrBuildingAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrBuildingAdapter.kt
@@ -1,7 +1,6 @@
 package com.pennapps.labs.pennmobile.adapters
 
 import android.content.Context
-import android.util.Log
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrBuildingAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrBuildingAdapter.kt
@@ -1,6 +1,7 @@
 package com.pennapps.labs.pennmobile.adapters
 
 import android.content.Context
+import android.util.Log
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrRoomAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrRoomAdapter.kt
@@ -1,12 +1,12 @@
 package com.pennapps.labs.pennmobile.adapters
 
 import android.content.Context
+import android.util.Log
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.pennapps.labs.pennmobile.*
-import com.pennapps.labs.pennmobile.classes.GSRRoom
 import org.joda.time.DateTime
 
 class GsrRoomAdapter(internal var timeRanges: ArrayList<String>, internal var ids: ArrayList<String>,
@@ -52,7 +52,6 @@ class GsrRoomAdapter(internal var timeRanges: ArrayList<String>, internal var id
         }
         return gsrRoomHolder
     }
-
 
     override fun onBindViewHolder(holder: GsrRoomHolder, position: Int) {
         if (position < itemCount) {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrRoomAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/GsrRoomAdapter.kt
@@ -1,7 +1,6 @@
 package com.pennapps.labs.pennmobile.adapters
 
 import android.content.Context
-import android.util.Log
 import androidx.fragment.app.FragmentTransaction
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater


### PR DESCRIPTION
Issue: booking GSRs for over 60, 90, or 120 minutes only actually books for 30 minutes 

Reason: on line 325 in GsrFragment.kt, the starting slot was used to retrieve the end time instead of the ending slot

Tests: booked a 60-min session in biotech and the confirmation email confirmed the duration. Yayay!

