### PR TITLE
fixed backstack navigation UX

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
@@ -135,7 +135,7 @@ class MainActivity : AppCompatActivity() {
                 "Laundry" -> fragment = LaundryFragment()
                 "More" -> fragment = MoreFragment()
             }
-            fragmentTransact(fragment)
+            fragmentTransact(fragment, true)
         }
     }
 
@@ -201,10 +201,14 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun fragmentTransact(fragment: Fragment?) {
+    fun fragmentTransact(fragment: Fragment?, popBackStack: Boolean) {
         if (fragment != null) {
             runOnUiThread {
                 try {
+                    //TODO ALI COMMENT
+                    if (popBackStack) {
+                        fragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    }
                     fragmentManager.beginTransaction()
                             .replace(R.id.content_frame, fragment)
                             .addToBackStack(null)

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeAdapter.kt
@@ -149,7 +149,7 @@ class HomeAdapter(private var cells: ArrayList<HomeCell>) :
         holder.itemView.home_card_subtitle.text = "DINING HALLS"
         holder.itemView.dining_prefs_btn.visibility = View.VISIBLE
         holder.itemView.dining_prefs_btn.setOnClickListener {
-            mActivity.fragmentTransact(DiningSettingsFragment())
+            mActivity.fragmentTransact(DiningSettingsFragment(), false)
         }
 
         mStudentLife.venues()
@@ -393,7 +393,7 @@ class HomeAdapter(private var cells: ArrayList<HomeCell>) :
 
         // For now, we only use Feature cards for Spring Fling so we show the Fling Fragment
         holder.itemView.home_post_card.setOnClickListener {
-            mActivity.fragmentTransact(FlingFragment())
+            mActivity.fragmentTransact(FlingFragment(), false)
         }
     }
         // Chrome custom tabs to launch news site

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeGsrBuildingAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeGsrBuildingAdapter.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.FragmentManager
 import com.pennapps.labs.pennmobile.GsrTabbedFragment
 import com.pennapps.labs.pennmobile.R
 import com.pennapps.labs.pennmobile.classes.CalendarEvent
@@ -41,7 +42,7 @@ class HomeGsrBuildingAdapter(private var buildings: ArrayList<String>)
             holder.itemView.home_gsr_building_iv.setImageResource(R.drawable.weigle)
         }
         holder.itemView.setOnClickListener {
-            fragmentTransact(GsrTabbedFragment())
+            fragmentTransact(GsrTabbedFragment(), false)
         }
 
     }
@@ -54,12 +55,15 @@ class HomeGsrBuildingAdapter(private var buildings: ArrayList<String>)
         val view = itemView
     }
 
-    private fun fragmentTransact(fragment: Fragment?) {
+    private fun fragmentTransact(fragment: Fragment?, popBackStack: Boolean) {
         if (fragment != null) {
             if (mContext is FragmentActivity) {
                 try {
                     val activity = mContext as FragmentActivity
                     val fragmentManager = activity.supportFragmentManager
+                    if (popBackStack) {
+                        fragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    }
                     fragmentManager.beginTransaction()
                             .replace(R.id.content_frame, fragment)
                             .addToBackStack("Main Activity")

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/more/PreferenceFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/more/PreferenceFragment.kt
@@ -93,19 +93,19 @@ class PreferenceFragment : PreferenceFragmentCompat() {
 
         val newsFeaturePref: Preference? = findPreference("pref_news_feature")
         newsFeaturePref?.setOnPreferenceClickListener {
-            mActivity.fragmentTransact(NewsFragment())
+            mActivity.fragmentTransact(NewsFragment(), false)
             return@setOnPreferenceClickListener true
         }
 
         val contactsFeaturePref: Preference? = findPreference("pref_contacts_feature")
         contactsFeaturePref?.setOnPreferenceClickListener {
-            mActivity.fragmentTransact(SupportFragment())
+            mActivity.fragmentTransact(SupportFragment(), false)
             return@setOnPreferenceClickListener true
         }
 
         val aboutFeaturePref: Preference? = findPreference("pref_about_feature")
         aboutFeaturePref?.setOnPreferenceClickListener {
-            mActivity.fragmentTransact(AboutFragment())
+            mActivity.fragmentTransact(AboutFragment(), false)
             return@setOnPreferenceClickListener true
         }
 


### PR DESCRIPTION
Issue: the back button navigates to every single previously-opened fragment before returning to the home page

Reason: fragment manager's backstack is never popped in the function `fragmentTransact` in `MainActivity.kt` line 204 and the function `functionTransact` in `HomeGsrBuildingAdapter.kt` line 58

Solution: 

1. Modified the signature for two functions called `fragmentTransact()`, one in `MainActivity.kt` and another in `HomeGsrBuildingAdapter.kt`, by adding a boolean argument `popBackStack`
2. Edited every call to these functions accordingly
3. Included conditional checks on `popBackStack` in the functions' bodies 
4. Popped the back stack accordingly using `fragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE`)
5. Handled the following edge cases by setting `popBackStack = false` when calling `fragmentTransact`: 
5.1. back navigation from any child of the About tab
5.2. back navigation from any child of the GSR tab
5.3. back navigation from any child of the Dining tab
5.4. back navigation from any child of the Laundry tab

