### PR TITLE
Version bumps

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -35,11 +35,11 @@ android {
         }
         release {}
     }
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion '29.0.3'
     defaultConfig {
-        minSdkVersion 18
-        targetSdkVersion 32
+        minSdkVersion 26
+        targetSdkVersion 33
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
         buildConfigField ("String", "PLATFORM_REDIRECT_URI", getPlatformRedirectUri())


### PR DESCRIPTION
Changing min to 26, target to 33.

We only have 1 user on Android 5 (rip) and bumping the version will make life a lot easier, especially since Android 26 is pretty old at this point and we can expect users to have this versh