### PR TITLE
Fix issue caused by duplicated main adapters causing crash:

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.preference.PreferenceManager
 import com.google.android.material.snackbar.Snackbar
-import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.pennapps.labs.pennmobile.adapters.DiningAdapter
 import com.pennapps.labs.pennmobile.api.StudentLife
 import com.pennapps.labs.pennmobile.classes.DiningHall
@@ -143,12 +143,21 @@ class DiningFragment : Fragment() {
                     mActivity.runOnUiThread {
                         getMenus(diningHalls)
                         val adapter = DiningAdapter(diningHalls)
-                        binding.diningHallsRecyclerView.adapter = adapter
                         loadingPanel?.visibility = View.GONE
                         if (diningHalls.size > 0) {
                             no_results?.visibility = View.GONE
                         }
-                        binding.diningSwiperefresh.isRefreshing = false
+
+                        // Log non-fatal error to crashyltics if null
+                        // this error should not really be happening
+                        // it is *possible* but be rare: ideally network stuff
+                        // is decoupled with UI updates
+                        try {
+                            binding.diningHallsRecyclerView.adapter = adapter
+                            binding.diningSwiperefresh.isRefreshing = false
+                        } catch (e: Exception) {
+                            FirebaseCrashlytics.getInstance().recordException(e)
+                        }
                         view?.let {displaySnack("Just Updated")}
                     }
                 }, {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningSettingsFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/DiningSettingsFragment.kt
@@ -14,6 +14,7 @@ import com.pennapps.labs.pennmobile.classes.DiningRequest
 import com.pennapps.labs.pennmobile.classes.HomepageDataModel
 import com.pennapps.labs.pennmobile.databinding.FragmentDiningPreferencesBinding
 import kotlinx.android.synthetic.main.include_main.toolbar
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 import retrofit.ResponseCallback
 import retrofit.RetrofitError
@@ -87,7 +88,11 @@ class DiningSettingsFragment(dataModel: HomepageDataModel) : Fragment() {
                 .subscribe({ diningHalls ->
                     mActivity.runOnUiThread {
                         halls = diningHalls
-                        binding.diningHallRv.adapter = DiningSettingsAdapter(diningHalls)
+                        try {
+                            binding.diningHallRv.adapter = DiningSettingsAdapter(diningHalls)
+                        } catch (e: Exception) {
+                            FirebaseCrashlytics.getInstance().recordException(e)
+                        }
                     }
                 }, {
                     Log.e("DiningSettings", "error fetching dining halls")

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundrySettingsFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/LaundrySettingsFragment.kt
@@ -3,13 +3,12 @@ package com.pennapps.labs.pennmobile
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
-import android.util.Log
 import android.view.*
 import android.widget.Button
 import android.widget.RelativeLayout
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
-import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.pennapps.labs.pennmobile.adapters.LaundrySettingsAdapter
 import com.pennapps.labs.pennmobile.api.StudentLife
 import com.pennapps.labs.pennmobile.classes.LaundryRoomSimple
@@ -123,7 +122,11 @@ class LaundrySettingsFragment : Fragment() {
                         }
 
                         val mAdapter = LaundrySettingsAdapter(mContext, hashMap, hallList)
-                        binding.laundryBuildingExpandableList.setAdapter(mAdapter)
+                        try {
+                            binding.laundryBuildingExpandableList.setAdapter(mAdapter)
+                        } catch (e: Exception) {
+                            FirebaseCrashlytics.getInstance().recordException(e)
+                        }
 
                         loadingPanel?.visibility = View.GONE
                         no_results?.visibility = View.GONE

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
@@ -84,11 +84,7 @@ class MainActivity : AppCompatActivity() {
 
         val policy = StrictMode.ThreadPolicy.Builder().permitAll().build()
         StrictMode.setThreadPolicy(policy)
-        val mainPagerAdapter = MainPagerAdapter(fragmentManager, lifecycle)
-        main_view_pager.setSaveEnabled(false);
-        main_view_pager.adapter = mainPagerAdapter
-        main_view_pager.isUserInputEnabled = false
-        main_view_pager.offscreenPageLimit = 5
+
         onExpandableBottomNavigationItemSelected()
         showBottomBar()
         supportActionBar?.setDisplayShowTitleEnabled(false)
@@ -142,6 +138,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
         val mainPagerAdapter = MainPagerAdapter(fragmentManager, lifecycle)
+        main_view_pager.setSaveEnabled(false);
         main_view_pager?.adapter = mainPagerAdapter
         main_view_pager.isUserInputEnabled = false
         main_view_pager.offscreenPageLimit = 5


### PR DESCRIPTION
Issue: First adapter is created which creates all the fragments. Dining fragment spawns new thread for network request. Then, startHomeFragment() is called in MainActivity, which creates a new adapter and destroys the old one. Then, the dining network request finishes and tries to access a null binding causing crash.

Added Crashyltics error logging for when this happens but prevents crash on the User side.