### PR TITLE
SDK Upgrade

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -27,7 +27,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 33
+        targetSdkVersion 34
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
         buildConfigField ("String", "PLATFORM_REDIRECT_URI", getPlatformRedirectUri())

--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -21,10 +21,10 @@ android {
         }
         release {}
     }
+    compileSdk 34
     buildFeatures {
         viewBinding true
     }
-    compileSdkVersion 33
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 33


### PR DESCRIPTION
Android SDK 34 Upgrade. Currently does not throw any errors but most likely requires further testing.