### PR TITLE
Fix broken blurview imports

### DIFF
--- a/.github/workflows/android-workflow.yaml
+++ b/.github/workflows/android-workflow.yaml
@@ -39,7 +39,7 @@ jobs:
 
       # Run unit tests
       - name: Run Unit Tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest --warning-mode all --stacktrace
   
   # If tests pass, generate and upload APK
   generate-apk:

--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -41,64 +41,68 @@ android {
 }
 
 dependencies {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'com.kaspersky.android-components:kaspresso:1.5.3'
+    androidTestImplementation 'org.testng:testng:7.8.0'
+
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:3.0-alpha-1'
 
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation(platform("com.google.firebase:firebase-bom:31.5.0"))
-
-    implementation 'com.google.firebase:firebase-analytics'
-    implementation("com.google.firebase:firebase-crashlytics")
-
-    implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.maps:google-maps-services:2.2.0'
-    implementation 'org.jsoup:jsoup:1.16.2'
-    implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.percentlayout:percentlayout:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.3.6'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'com.google.android.gms:play-services-maps:18.2.0'
-    implementation 'com.google.android.gms:play-services-location:21.0.1'
-    implementation 'joda-time:joda-time:2.12.5'
-    implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
     implementation 'androidx.annotation:annotation:1.7.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation ("androidx.lifecycle:lifecycle-extensions:2.2.0@aar") {
         transitive = true
     }
-    implementation 'com.squareup.retrofit:retrofit:1.9.0'
-    implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'
-    implementation 'io.reactivex:rxandroid:1.2.1'
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
     implementation 'androidx.browser:browser:1.5.0'
-    implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.daimajia.swipelayout:library:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.6.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'org.testng:testng:7.8.0'
-    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.github.ahorn:android-rss:master-SNAPSHOT'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
-    implementation 'com.eightbitlab:supportrenderscriptblur:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.6'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.palette:palette-ktx:1.0.0'
-    implementation 'com.github.searchy2:CustomAlertViewDialogue:2.6.1'
+    implementation 'androidx.percentlayout:percentlayout:1.0.0'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.airbnb.android:lottie:5.2.0'
+    implementation 'com.daimajia.swipelayout:library:1.2.0'
+    implementation 'com.github.Dimezis:BlurView:version-2.0.5'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+    implementation 'com.github.ahorn:android-rss:master-SNAPSHOT'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+    implementation('com.github.searchy2:CustomAlertViewDialogue:2.6.1'){
+        exclude group: 'com.eightbitlab', module: 'blurview'
+    }
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'com.google.android.gms:play-services-maps:18.2.0'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.6.0'
+    implementation 'com.google.maps:google-maps-services:2.2.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation 'com.kaspersky.android-components:kaspresso:1.5.3'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.okhttp:okhttp:2.7.5'
+    implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
     implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation 'io.reactivex:rxandroid:1.2.1'
+    implementation 'joda-time:joda-time:2.12.5'
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
+    implementation 'org.jsoup:jsoup:1.16.2'
+    implementation("com.google.firebase:firebase-crashlytics")
 
+    implementation(platform("com.google.firebase:firebase-bom:31.5.0"))
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 String getPlatformClientID() {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
@@ -51,7 +51,6 @@ import com.pennapps.labs.pennmobile.classes.Post
 import com.pennapps.labs.pennmobile.classes.Venue
 import com.pennapps.labs.pennmobile.components.sneaker.Sneaker
 import com.pennapps.labs.pennmobile.utils.Utils
-import eightbitlab.com.blurview.RenderScriptBlur
 import kotlinx.android.synthetic.main.custom_sneaker_view.view.blurView
 import kotlinx.android.synthetic.main.include_main.appbar
 import kotlinx.android.synthetic.main.include_main.content_frame
@@ -478,9 +477,7 @@ fun ViewGroup.showSneakerToast(
 
     view.blurView.setupWith(this)
         .setFrameClearDrawable(ColorDrawable(Color.TRANSPARENT))
-        .setBlurAlgorithm(RenderScriptBlur(this.context))
         .setBlurRadius(10f)
-        .setHasFixedTransformationMatrix(true)
         .setOverlayColor(resources.getColor(sneakerColor))
 
     val retryBtn = view.findViewById<TextView>(R.id.retryButton)

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/adapters/HomeAdapter.kt
@@ -54,7 +54,6 @@ import com.pennapps.labs.pennmobile.classes.Post
 import com.pennapps.labs.pennmobile.classes.PostCell
 import com.pennapps.labs.pennmobile.components.sneaker.Utils.convertToDp
 import com.pennapps.labs.pennmobile.utils.Utils
-import eightbitlab.com.blurview.RenderScriptBlur
 import kotlinx.android.synthetic.main.home_base_card.view.dining_prefs_btn
 import kotlinx.android.synthetic.main.home_base_card.view.home_card_rv
 import kotlinx.android.synthetic.main.home_base_card.view.home_card_subtitle
@@ -310,9 +309,7 @@ class HomeAdapter(private val dataModel: HomepageDataModel) :
         /** Sets up blur view on news card */
         holder.itemView.blurView.setupWith(holder.itemView.news_card_container)
             .setFrameClearDrawable(ColorDrawable(getColor(mContext, R.color.white)))
-            .setBlurAlgorithm(RenderScriptBlur(mContext))
             .setBlurRadius(25f)
-            .setHasFixedTransformationMatrix(true)
 
         holder.itemView.button.setOnClickListener {
             val url = article?.articleUrl
@@ -480,9 +477,7 @@ class HomeAdapter(private val dataModel: HomepageDataModel) :
         /** Sets up blur view on post card */
         holder.itemView.postBlurView.setupWith(holder.itemView.post_card_container)
             .setFrameClearDrawable(ColorDrawable(getColor(mContext, R.color.white)))
-            .setBlurAlgorithm(RenderScriptBlur(mContext))
             .setBlurRadius(25f)
-            .setHasFixedTransformationMatrix(true)
         /** Post clicking logic if there exists a URL **/
         val url = post?.postUrl ?: return
         holder.itemView.home_post_card.setOnClickListener {

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/components/dialog/CustomBlurDialogue.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/components/dialog/CustomBlurDialogue.java
@@ -58,9 +58,7 @@ public class CustomBlurDialogue extends BlurView {
 
         setupWith(rootView)
                 .setFrameClearDrawable(windowBackground)
-                .setBlurAlgorithm(new RenderScriptBlur(getContext()))
-                .setBlurRadius(radius)
-                .setHasFixedTransformationMatrix(true);
+                .setBlurRadius(radius);
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,19 @@
 pluginManagement {
     repositories {
         google()
-        mavenCentral()
         gradlePluginPortal()
+        mavenCentral()
     }
 }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
-        jcenter()
+        maven {
+            url "https://www.jitpack.io"
+        }
     }
 }
 


### PR DESCRIPTION
- Two imports from jCenter (`'com.eightbitlab:supportrenderscriptblur:1.0.2'` and `'com.eightbitlab:blurview:1.5.0'`) no longer exist which was causing the app to no longer build. I removed the first import since we no longer use this library. The second module was used by `'com.github.searchy2:CustomAlertViewDialogue:2.6.1'` so I excluded it and added the newer version which is on jitpack. 
- jCenter was removed from repositories since it has been deprecated for a while and we no longer need it.
- Added `--warning-mode all --stacktrace` flags to the `./gradlew` command in running unit tests so future errors are more readable.
- Dependencies in `build.gradle` were sorted for readability.