### PR TITLE
Crash hotfix

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
@@ -2,6 +2,7 @@ package com.pennapps.labs.pennmobile
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
@@ -242,27 +243,29 @@ class GsrFragment : Fragment() {
 
     private fun updateStatus() {
         mActivity.mNetworkManager.getAccessToken {
-            val bearerToken =
-                sharedPreferences.getString(getString(R.string.access_token), "").toString()
+            checkIfFragmentAttached {
+                val bearerToken =
+                    sharedPreferences.getString(getString(R.string.access_token), "").toString()
 
-            if (bearerToken.isEmpty()) {
-                Toast.makeText(activity, "You are not logged in!", Toast.LENGTH_LONG).show()
-            } else {
-                try {
-                    mStudentLife
-                        .isWharton(
-                            "Bearer $bearerToken",
-                        )?.subscribe(
-                            { status ->
-                                isWharton = status.isWharton
-                            },
-                            {
-                                Log.e("GsrFragment", "Error getting Wharton status", it)
-                                isWharton = false
-                            },
-                        )
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                if (bearerToken.isEmpty()) {
+                    Toast.makeText(activity, "You are not logged in!", Toast.LENGTH_LONG).show()
+                } else {
+                    try {
+                        mStudentLife
+                            .isWharton(
+                                "Bearer $bearerToken",
+                            )?.subscribe(
+                                { status ->
+                                    isWharton = status.isWharton
+                                },
+                                {
+                                    Log.e("GsrFragment", "Error getting Wharton status", it)
+                                    isWharton = false
+                                },
+                            )
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
                 }
             }
         }
@@ -679,6 +682,11 @@ class GsrFragment : Fragment() {
                     end,
                 )
             mGSRS.add(newGSRObject)
+        }
+    }
+    fun checkIfFragmentAttached(operation: Context.() -> Unit) {
+        if (isAdded && context != null) {
+            operation(requireContext())
         }
     }
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/GsrFragment.kt
@@ -684,6 +684,7 @@ class GsrFragment : Fragment() {
             mGSRS.add(newGSRObject)
         }
     }
+
     fun checkIfFragmentAttached(operation: Context.() -> Unit) {
         if (isAdded && context != null) {
             operation(requireContext())

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
@@ -109,7 +109,7 @@ class MenuFragment : Fragment() {
 
     override fun onViewCreated(
         view: View,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
         mActivity.toolbar.visibility = View.VISIBLE

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
@@ -107,7 +107,10 @@ class MenuFragment : Fragment() {
         return v
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
         super.onViewCreated(view, savedInstanceState)
         mActivity.toolbar.visibility = View.VISIBLE
     }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
@@ -103,9 +103,13 @@ class MenuFragment : Fragment() {
         pager.adapter = pageAdapter
         v.setBackgroundColor(Color.WHITE)
         mActivity.addTabs(pageAdapter as TabAdapter, pager, true)
-        mActivity.toolbar.visibility = View.VISIBLE
         mActivity.hideBottomBar()
         return v
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        mActivity.toolbar.visibility = View.VISIBLE
     }
 
     override fun onCreateOptionsMenu(

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MenuFragment.kt
@@ -88,9 +88,7 @@ class MenuFragment : Fragment() {
         super.onCreate(savedInstanceState)
         mDiningHall = arguments?.getParcelable("DiningHall")
         mActivity = activity as MainActivity
-        mActivity.toolbar.visibility = View.VISIBLE
         setHasOptionsMenu(true)
-        mActivity.hideBottomBar()
     }
 
     override fun onCreateView(
@@ -105,6 +103,8 @@ class MenuFragment : Fragment() {
         pager.adapter = pageAdapter
         v.setBackgroundColor(Color.WHITE)
         mActivity.addTabs(pageAdapter as TabAdapter, pager, true)
+        mActivity.toolbar.visibility = View.VISIBLE
+        mActivity.hideBottomBar()
         return v
     }
 


### PR DESCRIPTION
Added fixes to the following crashes:

- MenuFragment NullPointerException: Moved toolbar visibility method to OnViewCreate so method won't be invoked on a null view (view is null at OnCreate())

- GSRFragment IllegalStateException: Performs a context check at the getString operation at updateStatus() method to prevent method being called on a null context (The IllegalStateException is thrown when requireContext detects the context is null).
