### PR TITLE
Fix cancelGSR API field so the app could properly cancel reservations

### DIFF
--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/StudentLife.java
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/StudentLife.java
@@ -131,7 +131,7 @@ public interface StudentLife {
     void cancelReservation(
             @Header("Authorization") String bearerToken,
             @Header("X-Device-ID") String deviceID,
-            @Field("bookingId") String bookingID,
+            @Field("booking_id") String bookingID,
             @Field("sessionid") String sessionID,
             Callback<Response> callback);
 


### PR DESCRIPTION
ktlint apparently autoformatted the @Field("booking_id") from snake_case to camelCase back in Rohan's listing commit, causing retrofit errors every time users try to cancel the gsr (fields don't match). We gotta be a bit more careful when auto-linting next time rip. 