### PR TITLE
Introducing... Jetpack Compose!

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -17,13 +17,21 @@ android {
     buildTypes {
         debug {
             matchingFallbacks = ['qa', 'release']
-            testCoverageEnabled true
+            enableUnitTestCoverage true
+            enableAndroidTestCoverage true
         }
         release {}
     }
     compileSdk 34
     buildFeatures {
         viewBinding true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
     defaultConfig {
         minSdkVersion 26
@@ -34,9 +42,10 @@ android {
         buildConfigField ("String", "PLATFORM_CLIENT_ID", getPlatformClientID())
     }
     packagingOptions {
-        pickFirst 'META-INF/LICENSE.txt'
-        pickFirst 'META-INF/NOTICE.txt'
-        exclude 'META-INF/rxjava.properties'
+        resources {
+            excludes += ['META-INF/rxjava.properties']
+            pickFirsts += ['META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
+        }
     }
 }
 
@@ -99,6 +108,28 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
     implementation 'org.jsoup:jsoup:1.16.2'
     implementation("com.google.firebase:firebase-crashlytics")
+
+    def composeBom = platform("androidx.compose:compose-bom:2024.09.03")
+    implementation composeBom
+    testImplementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.material3:material3-android'
+    implementation 'androidx.compose.runtime:runtime'
+    implementation 'androidx.compose.runtime:runtime-rxjava2'
+    implementation 'androidx.compose.runtime:runtime-livedata'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    implementation 'androidx.compose.material:material-icons-core'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.activity:activity-compose:1.8.0'
+
+    implementation "androidx.glance:glance-appwidget:1.1.0"
+    implementation "androidx.glance:glance-material3:1.1.0"
+    implementation "androidx.glance:glance-material:1.1.0"
 
     implementation(platform("com.google.firebase:firebase-bom:31.5.0"))
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SupportFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/SupportFragment.kt
@@ -49,7 +49,7 @@ class SupportFragment : ListFragment() {
         savedInstanceState: Bundle?,
     ): View? {
         val view = inflater.inflate(R.layout.fragment_support, container, false)
-        setHasOptionsMenu(false)
+        setHasOptionsMenu(true)
         return view
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/components/floatingbottombar/ExpandableItemViewController.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/components/floatingbottombar/ExpandableItemViewController.kt
@@ -49,11 +49,11 @@ internal open class ExpandableItemViewController(
             itemView,
             object : AccessibilityDelegateCompat() {
                 override fun onInitializeAccessibilityNodeInfo(
-                    host: View?,
-                    info: AccessibilityNodeInfoCompat?,
+                    host: View,
+                    info: AccessibilityNodeInfoCompat,
                 ) {
-                    info?.setTraversalAfter(prev?.itemView)
-                    info?.setTraversalBefore(next?.itemView)
+                    info.setTraversalAfter(prev?.itemView)
+                    info.setTraversalBefore(next?.itemView)
                     super.onInitializeAccessibilityNodeInfo(host, info)
                 }
             },

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.2' apply false
-    id 'com.android.library' version '8.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.22' apply false
+    id 'com.android.application' version '8.6.1' apply false
+    id 'com.android.library' version '8.6.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
     id 'com.google.gms.google-services' version "4.4.0" apply false
     id("com.google.firebase.crashlytics") version "2.9.9" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Dec 01 16:55:01 EST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### **Jetpack compose is here!**

1. Enabled Jetpack compose in gradle and added some dependencies like Material3 and Glance
2. Upgraded AGP to 8.6.1 so we can prepare for the next target API upgrade (requires 8.6.0 minimum)
3. Upgraded Kotlin to 1.9.24 for now. We can soon also start migrating to Kotlin 2.0 (but it might take a while cuz there are tons of changes and deprecations with a brand new compiler)

