### PR TITLE
Sdk35 Update

### DIFF
--- a/PennMobile/build.gradle
+++ b/PennMobile/build.gradle
@@ -20,7 +20,7 @@ android {
         }
         release {}
     }
-    compileSdk 34
+    compileSdk 35
     buildFeatures {
         viewBinding true
         compose true
@@ -33,7 +33,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
         buildConfigField ("String", "PLATFORM_REDIRECT_URI", getPlatformRedirectUri())

--- a/PennMobile/src/main/AndroidManifest.xml
+++ b/PennMobile/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
-        android:theme="@style/AppTheme.Launcher"
+        android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
         tools:targetApi="m">
         <receiver

--- a/PennMobile/src/main/AndroidManifest.xml
+++ b/PennMobile/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
-        android:name="androidx.multidex.MultiDexApplication"
+        android:name=".PennMobile"
         android:label="@string/app_name"
         android:allowBackup="true"
         android:hardwareAccelerated="true"

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/MainActivity.kt
@@ -21,6 +21,7 @@ import android.view.inputmethod.InputMethodManager
 import android.webkit.CookieManager
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.graphics.ColorUtils
@@ -79,6 +80,9 @@ class MainActivity : AppCompatActivity() {
             setTheme(R.style.DarkModeApi29)
         }
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+
         setTheme(R.style.AppTheme)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NotificationsSettingsView.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NotificationsSettingsView.kt
@@ -1,0 +1,139 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationSettingsList(settingsList: List<Pair<String, Boolean>>) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            Column {
+                CenterAlignedTopAppBar(
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = Color.White,
+                        titleContentColor = MaterialTheme.colorScheme.onBackground,
+                    ),
+                    title = {
+                        Text(
+                            "Notification Settings",
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = { /* handle back */ }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Go Back"
+                            )
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { saveNotificationSettings() }) {
+                            Icon(
+                                imageVector = Icons.Filled.Save,
+                                contentDescription = "Save"
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+                HorizontalDivider(thickness = 1.dp, color = Color.LightGray,
+                    modifier = Modifier.padding(horizontal = 24.dp))
+            }
+        },
+        content = { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = Color.White)
+                    .padding(innerPadding)
+            ) {
+                Text(
+                    text = "Alerts",
+                    modifier = Modifier
+                        .padding(start = 32.dp, top = 32.dp, end = 32.dp, bottom = 4.dp),
+                    color = Color(0xFF339FE6)
+                )
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                ) {
+                    items(settingsList) { setting ->
+                        NotificationSettingRow(
+                            label = setting.first,
+                            isEnabledInitial = setting.second
+                        )
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun NotificationSettingRow(label: String, isEnabledInitial: Boolean) {
+    var isEnabled by remember { mutableStateOf(isEnabledInitial) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+
+        Switch(
+            checked = isEnabled,
+            onCheckedChange = { isChecked ->
+                isEnabled = isChecked
+            },
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                uncheckedThumbColor = Color.Gray.copy(alpha = 0.5f),
+                checkedTrackColor = Color(0xFF6ED668),
+                uncheckedTrackColor = Color.LightGray.copy(alpha = 0.5f),
+                checkedBorderColor = Color.Transparent,
+                uncheckedBorderColor = Color.Transparent
+            )
+        )
+    }
+}
+
+// Do later
+fun saveNotificationSettings() {
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AppWithListPreview() {
+    var settingsList = listOf(
+        "Penn Course Alert" to false,
+        "Laundry" to true,
+        "GSR Bookings" to true,
+        "OHQ" to true
+    )
+    NotificationSettingsList(settingsList)
+}

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NotificationsSettingsView.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/NotificationsSettingsView.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -15,6 +17,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
+@Suppress("ktlint:standard:function-naming")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationSettingsList(settingsList: List<Pair<String, Boolean>>) {
@@ -25,22 +28,23 @@ fun NotificationSettingsList(settingsList: List<Pair<String, Boolean>>) {
         topBar = {
             Column {
                 CenterAlignedTopAppBar(
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                        containerColor = Color.White,
-                        titleContentColor = MaterialTheme.colorScheme.onBackground,
-                    ),
+                    colors =
+                        TopAppBarDefaults.centerAlignedTopAppBarColors(
+                            containerColor = Color.White,
+                            titleContentColor = MaterialTheme.colorScheme.onBackground,
+                        ),
                     title = {
                         Text(
                             "Notification Settings",
                             maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
                         )
                     },
                     navigationIcon = {
                         IconButton(onClick = { /* handle back */ }) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Go Back"
+                                contentDescription = "Go Back",
                             )
                         }
                     },
@@ -48,60 +52,71 @@ fun NotificationSettingsList(settingsList: List<Pair<String, Boolean>>) {
                         IconButton(onClick = { saveNotificationSettings() }) {
                             Icon(
                                 imageVector = Icons.Filled.Save,
-                                contentDescription = "Save"
+                                contentDescription = "Save",
                             )
                         }
                     },
                     scrollBehavior = scrollBehavior,
                 )
-                HorizontalDivider(thickness = 1.dp, color = Color.LightGray,
-                    modifier = Modifier.padding(horizontal = 24.dp))
+                HorizontalDivider(
+                    thickness = 1.dp,
+                    color = Color.LightGray,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
             }
         },
         content = { innerPadding ->
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(color = Color.White)
-                    .padding(innerPadding)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(color = Color.White)
+                        .padding(innerPadding),
             ) {
                 Text(
                     text = "Alerts",
-                    modifier = Modifier
-                        .padding(start = 32.dp, top = 32.dp, end = 32.dp, bottom = 4.dp),
-                    color = Color(0xFF339FE6)
+                    modifier =
+                        Modifier
+                            .padding(start = 32.dp, top = 32.dp, end = 32.dp, bottom = 4.dp),
+                    color = Color(0xFF339FE6),
                 )
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier =
+                        Modifier
+                            .fillMaxSize(),
                 ) {
                     items(settingsList) { setting ->
                         NotificationSettingRow(
                             label = setting.first,
-                            isEnabledInitial = setting.second
+                            isEnabledInitial = setting.second,
                         )
                     }
                 }
             }
-        }
+        },
     )
 }
 
+@Suppress("ktlint:standard:function-naming")
 @Composable
-fun NotificationSettingRow(label: String, isEnabledInitial: Boolean) {
+fun NotificationSettingRow(
+    label: String,
+    isEnabledInitial: Boolean,
+) {
     var isEnabled by remember { mutableStateOf(isEnabledInitial) }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 32.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onBackground
+            color = MaterialTheme.colorScheme.onBackground,
         )
 
         Switch(
@@ -109,31 +124,33 @@ fun NotificationSettingRow(label: String, isEnabledInitial: Boolean) {
             onCheckedChange = { isChecked ->
                 isEnabled = isChecked
             },
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                uncheckedThumbColor = Color.Gray.copy(alpha = 0.5f),
-                checkedTrackColor = Color(0xFF6ED668),
-                uncheckedTrackColor = Color.LightGray.copy(alpha = 0.5f),
-                checkedBorderColor = Color.Transparent,
-                uncheckedBorderColor = Color.Transparent
-            )
+            colors =
+                SwitchDefaults.colors(
+                    checkedThumbColor = Color.White,
+                    uncheckedThumbColor = Color.Gray.copy(alpha = 0.5f),
+                    checkedTrackColor = Color(0xFF6ED668),
+                    uncheckedTrackColor = Color.LightGray.copy(alpha = 0.5f),
+                    checkedBorderColor = Color.Transparent,
+                    uncheckedBorderColor = Color.Transparent,
+                ),
         )
     }
 }
 
 // Do later
 fun saveNotificationSettings() {
-
 }
 
+@Suppress("ktlint:standard:function-naming")
 @Preview(showBackground = true)
 @Composable
 fun AppWithListPreview() {
-    var settingsList = listOf(
-        "Penn Course Alert" to false,
-        "Laundry" to true,
-        "GSR Bookings" to true,
-        "OHQ" to true
-    )
+    var settingsList =
+        listOf(
+            "Penn Course Alert" to false,
+            "Laundry" to true,
+            "GSR Bookings" to true,
+            "OHQ" to true,
+        )
     NotificationSettingsList(settingsList)
 }

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/PennMobile.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/PennMobile.kt
@@ -1,0 +1,26 @@
+package com.pennapps.labs.pennmobile
+
+import android.os.Build
+import android.os.StrictMode
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.multidex.MultiDexApplication
+
+class PennMobile : MultiDexApplication() {
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun onCreate() {
+        super.onCreate()
+
+        if (BuildConfig.DEBUG) {
+            Log.d("StrictMode", "VM policy set")
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy
+                    .Builder()
+                    .detectUnsafeIntentLaunch()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build(),
+            )
+        }
+    }
+}

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.preference.PreferenceManager

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.preference.PreferenceManager

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginWebviewFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/api/fragments/LoginWebviewFragment.kt
@@ -18,6 +18,8 @@ import android.webkit.WebViewClient
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
@@ -44,7 +46,9 @@ class LoginWebviewFragment : Fragment() {
     lateinit var webView: WebView
     lateinit var headerLayout: LinearLayout
     lateinit var cancelButton: Button
+    lateinit var status: View
     lateinit var user: Account
+    lateinit var root: LinearLayout
     private lateinit var mStudentLife: StudentLife
     private var mPlatform: Platform? = null
     private lateinit var mActivity: MainActivity
@@ -87,9 +91,22 @@ class LoginWebviewFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+
+        root = view.findViewById(R.id.root)
+        status = view.findViewById(R.id.statusBarInset)
         webView = view.findViewById(R.id.webView)
         headerLayout = view.findViewById(R.id.linear_layout)
         cancelButton = view.findViewById(R.id.cancel_button)
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            status.layoutParams =
+                status.layoutParams.apply {
+                    height = bars.top
+                }
+            v.setPadding(bars.left, v.paddingTop, bars.right, v.paddingBottom)
+            insets
+        }
 
         webView.loadUrl(platformAuthUrl)
         val webSettings = webView.settings

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/dining/adapters/DiningInsightsCardAdapter.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/dining/adapters/DiningInsightsCardAdapter.kt
@@ -54,7 +54,7 @@ class DiningInsightsCardAdapter(
         private const val DINING_DOLLARS_PREDICTIONS = 2
         private const val DINING_SWIPES_PREDICTIONS = 3
 
-        const val START_DAY_OF_SEMESTER = "2025-01-15"
+        const val START_DAY_OF_SEMESTER = "2025-08-26"
         private const val DAYS_IN_SEMESTER = 117f
     }
 

--- a/PennMobile/src/main/java/com/pennapps/labs/pennmobile/dining/fragments/DiningInsightsFragment.kt
+++ b/PennMobile/src/main/java/com/pennapps/labs/pennmobile/dining/fragments/DiningInsightsFragment.kt
@@ -92,6 +92,7 @@ class DiningInsightsFragment : Fragment() {
                 .commit()
         }
         getInsights(accessToken)
+        Log.d("Campus Express", "$accessToken")
         // Inflate the layout for this fragment
         return view
     }

--- a/PennMobile/src/main/res/layout/fragment_dining_holder.xml
+++ b/PennMobile/src/main/res/layout/fragment_dining_holder.xml
@@ -14,6 +14,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/fragment_fitness_holder.xml
+++ b/PennMobile/src/main/res/layout/fragment_fitness_holder.xml
@@ -14,6 +14,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/fragment_gsr_tabs.xml
+++ b/PennMobile/src/main/res/layout/fragment_gsr_tabs.xml
@@ -16,6 +16,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/fragment_home.xml
+++ b/PennMobile/src/main/res/layout/fragment_home.xml
@@ -14,6 +14,7 @@
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
         app:elevation="0dp"
+        android:fitsSystemWindows="true"
         tools:targetApi="lollipop">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/fragment_laundry.xml
+++ b/PennMobile/src/main/res/layout/fragment_laundry.xml
@@ -14,6 +14,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp"
         >
 

--- a/PennMobile/src/main/res/layout/fragment_login.xml
+++ b/PennMobile/src/main/res/layout/fragment_login.xml
@@ -21,7 +21,7 @@
         android:id="@+id/pennmobile_logo_iv"
         android:layout_width="100dp"
         android:layout_height="100dp"
-        android:layout_marginTop="120dp"
+        android:layout_marginTop="180dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/PennMobile/src/main/res/layout/fragment_login.xml
+++ b/PennMobile/src/main/res/layout/fragment_login.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
 
     <ImageView
+        android:contentDescription="@string/login_background"
         android:id="@+id/background_iv"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -18,6 +18,7 @@
         app:srcCompat="@drawable/login_background" />
 
     <ImageView
+        android:contentDescription="@string/penn_mobile_icon"
         android:id="@+id/pennmobile_logo_iv"
         android:layout_width="100dp"
         android:layout_height="100dp"

--- a/PennMobile/src/main/res/layout/fragment_login_webview.xml
+++ b/PennMobile/src/main/res/layout/fragment_login_webview.xml
@@ -30,7 +30,7 @@
                 android:id="@+id/cancel_button"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:text="Cancel"
+                android:text="@string/cancel"
                 android:layout_weight="2"
                 android:layout_marginLeft="5dp"
                 android:textSize="15sp"

--- a/PennMobile/src/main/res/layout/fragment_login_webview.xml
+++ b/PennMobile/src/main/res/layout/fragment_login_webview.xml
@@ -7,17 +7,24 @@
     tools:context=".api.fragments.LoginWebviewFragment">
 
     <LinearLayout
+        android:id="@+id/root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
         android:background="#FFF">
 
+        <View
+            android:id="@+id/statusBarInset"
+            android:layout_width="match_parent"
+            android:layout_height="0dp" />
+
         <LinearLayout
             android:id="@+id/linear_layout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="13"
-            android:orientation="horizontal">
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:elevation="8dp">
 
             <Button
                 android:id="@+id/cancel_button"
@@ -49,8 +56,8 @@
         <WebView
             android:id="@+id/webView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
+            android:layout_height="0dp"
+            android:layout_weight="12"
             android:background="#00FFFDFD" />
 
     </LinearLayout>

--- a/PennMobile/src/main/res/layout/fragment_menu.xml
+++ b/PennMobile/src/main/res/layout/fragment_menu.xml
@@ -4,6 +4,6 @@
     android:id="@+id/menu_pager"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginTop="100dp"
+    android:layout_marginTop="150dp"
     android:background="@android:color/background_light"
     app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/PennMobile/src/main/res/layout/fragment_menu_tab.xml
+++ b/PennMobile/src/main/res/layout/fragment_menu_tab.xml
@@ -12,5 +12,6 @@
             android:layout_height="wrap_content"
             android:groupIndicator="@null"/>
 
+
         <!-- Menus inserted here programmatically -->
     </LinearLayout>

--- a/PennMobile/src/main/res/layout/fragment_more.xml
+++ b/PennMobile/src/main/res/layout/fragment_more.xml
@@ -19,6 +19,7 @@
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
         app:elevation="0dp"
+        android:fitsSystemWindows="true"
         tools:targetApi="lollipop">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/fragment_news.xml
+++ b/PennMobile/src/main/res/layout/fragment_news.xml
@@ -18,6 +18,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp"
         tools:targetApi="lollipop">
 

--- a/PennMobile/src/main/res/layout/fragment_penn_course_alert_holder.xml
+++ b/PennMobile/src/main/res/layout/fragment_penn_course_alert_holder.xml
@@ -14,6 +14,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/PennMobile/src/main/res/layout/fragment_pottruck.xml
+++ b/PennMobile/src/main/res/layout/fragment_pottruck.xml
@@ -14,6 +14,7 @@
         android:background="@color/white"
         android:elevation="0dp"
         android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true"
         app:elevation="0dp">
 
         <FrameLayout

--- a/PennMobile/src/main/res/layout/include_main.xml
+++ b/PennMobile/src/main/res/layout/include_main.xml
@@ -56,7 +56,7 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/expandable_bottom_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/nav_bar_height"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:background="@color/white"
         android:visibility="gone"

--- a/PennMobile/src/main/res/layout/include_main.xml
+++ b/PennMobile/src/main/res/layout/include_main.xml
@@ -18,9 +18,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
+            app:statusBarForeground="@android:color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
+
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"

--- a/PennMobile/src/main/res/layout/include_main.xml
+++ b/PennMobile/src/main/res/layout/include_main.xml
@@ -17,6 +17,7 @@
             android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:fitsSystemWindows="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">

--- a/PennMobile/src/main/res/values/dimens.xml
+++ b/PennMobile/src/main/res/values/dimens.xml
@@ -10,7 +10,7 @@
     <dimen name="gym_imageview_width">150dp</dimen>
     <dimen name="card_imageview_padding">5dp</dimen>
     <dimen name="bottom_nav_icon_size">24dp</dimen>
-    <dimen name="nav_bar_height">65dp</dimen>
+    <dimen name="nav_bar_height">80dp</dimen>
     <dimen name="app_bar_height">80dp</dimen>
 
     <!--

--- a/PennMobile/src/main/res/values/strings.xml
+++ b/PennMobile/src/main/res/values/strings.xml
@@ -240,4 +240,7 @@
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">This is an app widget description</string>
     <string name="you_have_no_reservations_or_are_logged_out">You have no reservations or are logged out</string>
+    <string name="login_background">Login Background</string>
+    <string name="penn_mobile_icon">Penn Mobile Icon</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/PennMobile/src/main/res/values/styles.xml
+++ b/PennMobile/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
     </style>
 
     <style name="AppTheme.Launcher">
-        <item name="android:windowBackground">@drawable/splash_screen</item>
+        <item name="android:windowBackground">@drawable/login_background</item>
     </style>
 
     <style name="Widget.AppTheme.Launcher.ListView" parent="android:Widget.ListView">


### PR DESCRIPTION
### **API 35 Upgrade ChangeLog**

1. Foreground Services
    1. dataSync (6 hrs) timeout
    2. `mediaProcessing` FGS (Foreground Service)
    3. `BOOT_COMPLETED` receivers can’t start certain FGS types
    4.  Starting FGS while holding `SYSTEM_ALERT_WINDOW` (SAW) is stricter
    5.  Do Not Disturb (DND) global state
    <br>
   - Impact: NonImpact since our app does not use foreground services. However, we would need to keep in mind these when we go deeper into notifs (respect DND, don’t change the global state unless you plan to contribute a AutomaticZenRule) or want to implement dataSync or mediaProcessing service features

2. Security
    1. TLS1.0/1.1 Disallowed
       - Impact: As far as surveying the codebase, we do not explicitly enable these legacy protocols on OkHTTP or manually define to negotiate TLSv1 or TLSv1.1, so this does not impact our app
    2. Secured background activity launches tightened
       - Impact: Our app does not call any activities from the background (via PendingIntent). AppWidgets’ PendingIntents have a visible launcher from our app that fires the startActivity, so they’re not from the background. However, keep an eye on the rest of these PendingIntent fires when utilizing it in the future, as it would be blocked by the OS unless the client opted in BAL:
         1.  AlarmManager is going off (Set 5 minutes and open the app suddenly)
         2.  a BroadcastReceiver running in the background
         3.  a background Service calling pendingIntent.send(...)
    3.  Safe Intents
        - Implicit Intents must have an action (setAction() or an action flag → Intent.ACTION_VIEW) and match filters, or have an explicit target provided upon definition (EX: Intent(context, MainActivity::class.java))
        - Impact:  I have currently checked the codebase, and so far, the intents seem to be safe. I also added a StrictMode policy established under debug mode that would crash and log these unsafe intents if we were to accidentally code one in the future 

3. Camera and Media
    1. Audio Focus Requests Restricted
        - Impact: We don’t use any camera and media stuff, so this does not affect us. If we were to implement these features in the future, be careful not to call AudioManager.requestAudioFocus(...) while not the top app and not running an appropriate FGS.


4. UI and Text
    1. Text Rendering Default Change
        -  Impact: We don't use any of the languages (Arabic, Lao, Myanmar, Tamil, Gujarati, Kannada, Malayalam, Odia, Telugu, or Thai) that experienced a rendering change 
    2.  EDGE-TO-EDGE ENFORCEMENT
        -  The majority of the changes are involved in this PR. Check out this Notion markdown [here](https://www.notion.so/pennlabs/API-Level-35-Update-1bacc06be4ae80c8ad26d639943835ff) for the details, as it's pretty lengthy. 



